### PR TITLE
Aggregates

### DIFF
--- a/lib/vanity/metric/active_record.rb
+++ b/lib/vanity/metric/active_record.rb
@@ -57,7 +57,7 @@ module Vanity
       def values(sdate, edate)
         query = { :conditions=>{ @ar_timestamp=>(sdate.to_time...(edate + 1).to_time) },
                   :group=>"date(#{@ar_scoped.connection.quote_column_name @ar_timestamp})" }
-        grouped = @ar_column ? @ar_scoped.calculate(@ar_aggregate, @ar_column, query) : @ar_scoped.count(query)
+        grouped = @ar_column ? @ar_scoped.send(@ar_aggregate, @ar_column, query) : @ar_scoped.count(query)
         (sdate..edate).inject([]) { |ordered, date| ordered << (grouped[date.to_s] || 0) }
       end
 

--- a/test/metric/active_record_test.rb
+++ b/test/metric/active_record_test.rb
@@ -42,7 +42,6 @@ context "ActiveRecord Metric" do
   end
 
   test "record average" do
-    Sky.aggregates
     File.open "tmp/experiments/metrics/sky_is_limit.rb", "w" do |f|
       f.write <<-RUBY
         metric "Sky is limit" do
@@ -51,13 +50,12 @@ context "ActiveRecord Metric" do
       RUBY
     end
     Vanity.playground.metrics
-    Sky.create! :height=>4
+    Sky.create! :height=>8
     Sky.create! :height=>2
-    assert_equal 3, Vanity::Metric.data(metric(:sky_is_limit)).last.last
+    assert_equal 5, Vanity::Metric.data(metric(:sky_is_limit)).last.last
   end
 
   test "record minimum" do
-    Sky.aggregates
     File.open "tmp/experiments/metrics/sky_is_limit.rb", "w" do |f|
       f.write <<-RUBY
         metric "Sky is limit" do
@@ -72,7 +70,6 @@ context "ActiveRecord Metric" do
   end
 
   test "record maximum" do
-    Sky.aggregates
     File.open "tmp/experiments/metrics/sky_is_limit.rb", "w" do |f|
       f.write <<-RUBY
         metric "Sky is limit" do
@@ -108,7 +105,6 @@ context "ActiveRecord Metric" do
   end
 
   test "with scope" do
-    Sky.aggregates
     File.open "tmp/experiments/metrics/sky_is_limit.rb", "w" do |f|
       f.write <<-RUBY
         metric "Sky is limit" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,7 +84,7 @@ class Test::Unit::TestCase
     Vanity.playground.collecting = false
     Vanity.playground.stubs(:connection).returns(stub(:flushdb=>nil))
   end
-  
+
   def teardown
     Vanity.context = nil
     FileUtils.rm_rf "tmp"
@@ -101,32 +101,6 @@ end
 
 ActiveRecord::Base.logger = $logger
 ActiveRecord::Base.establish_connection :adapter=>"sqlite3", :database=>File.expand_path("database.sqlite")
-# Call this to define aggregate functions not available in SQlite.
-class ActiveRecord::Base
-  def self.aggregates
-    connection.raw_connection.create_aggregate("minimum", 1) do
-      step do |func, value|
-        func[:minimum] = value.to_i unless func[:minimum] && func[:minimum].to_i < value.to_i
-      end
-      finalize { |func| func.result = func[:minimum] }
-    end
-
-    connection.raw_connection.create_aggregate("maximum", 1) do
-      step do |func, value|
-        func[:maximum] = value.to_i unless func[:maximum] && func[:maximum].to_i > value.to_i
-      end
-      finalize { |func| func.result = func[:maximum] }
-    end
-
-    connection.raw_connection.create_aggregate("average", 1) do
-      step do |func, value|
-        func[:total] = func[:total].to_i + value.to_i
-        func[:count] = func[:count].to_i + 1
-      end
-      finalize { |func| func.result = func[:total].to_i / func[:count].to_i }
-    end
-  end
-end
 
 
 class Array
@@ -134,7 +108,7 @@ class Array
   unless method_defined?(:shuffle)
     def shuffle
       copy = clone
-      Array.new(size) { copy.delete_at(Kernel.rand(copy.size)) } 
+      Array.new(size) { copy.delete_at(Kernel.rand(copy.size)) }
     end
   end
 end
@@ -145,7 +119,7 @@ def context(*args, &block)
   return super unless (name = args.first) && block
   parent = Class === self ? self : (defined?(ActiveSupport::TestCase) ? ActiveSupport::TestCase : Test::Unit::TestCase)
   klass = Class.new(parent) do
-    def self.test(name, &block) 
+    def self.test(name, &block)
       define_method("test_#{name.gsub(/\W/,'_')}", &block) if block
     end
     def self.xtest(*args) end


### PR DESCRIPTION
Hi there assaf,

First off, thanks for creating Vanity. It's a very cool library!

While trying to track a metric using an average aggregate, I was getting errors that the sql function 'average' was invalid. I tested with both sqlite and postgres with no luck, so started digging into the code. 

After tracking down where the query was being generated in vanity, I discovered that essentially, vanity calls calculate(:average, ....), whereas, if you look at the (Rails 2.3.8) ActiveRecord source for it's own average method, it calls calculate(:avg, ...) - which works properly with sqlite, mysql, and postgres. The same applies for minimum (min), and maximum (max). I changed the code to call the appropriate aggregation method in ActiveRecord directly, rather than calling calculate, as this seems safer and should work with all adapters. If you could take a look and let me know what you think.

Thanks!
