### PR TITLE
This was really frustrating to track down.

### DIFF
--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -16,7 +16,7 @@ module Vanity
     class RedisAdapter < AbstractAdapter
       def initialize(options)
         @options = options.clone
-        @options[:db] = @options[:database] || (@options[:path] && @options[:path].split("/")[1].to_i)
+        @options[:db] ||= @options[:database] || (@options[:path] && @options[:path].split("/")[1].to_i)
         @options[:thread_safe] = true
         connect!
       end


### PR DESCRIPTION
I set adapter to redis in my vanity.yml and then set the rest of the options exactly as Redis.rb expects. the :db option was always set to nil though when Redis.rb got it, this is why.
