### PR TITLE
Rails.logger reference needs :: prefix

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -2,7 +2,7 @@ module Vanity
   module Rails #:nodoc:
     def self.load!
       Vanity.playground.load_path = ::Rails.root + Vanity.playground.load_path
-      Vanity.playground.logger ||= Rails.logger
+      Vanity.playground.logger ||= ::Rails.logger
 
       # Do this at the very end of initialization, allowing you to change
       # connection adapter, turn collection on/off, etc.
@@ -148,11 +148,11 @@ module Vanity
           value
         end
       end
-      
+
       def vanity_h(text)
         h(text)
       end
-      
+
       def vanity_html_safe(text)
         if text.respond_to?(:html_safe!)
           text.html_safe!
@@ -160,8 +160,8 @@ module Vanity
           text
         end
       end
-      
-      def vanity_simple_format(text, html_options={}) 
+
+      def vanity_simple_format(text, html_options={})
         vanity_html_safe(simple_format(text, html_options))
       end
     end


### PR DESCRIPTION
Tiny fix... the reference to Rails.logger in the rails framework module needed a :: prefix.  It was throwing an exception at boot of my app.
