### PR TITLE
Duplicate metrics rendering

### DIFF
--- a/lib/vanity/templates/_metrics.erb
+++ b/lib/vanity/templates/_metrics.erb
@@ -2,7 +2,6 @@
   <% metrics.sort_by { |id, metric| metric.name }.each do |id, metric| %>
     <li class="metric" id="metric_<%= id %>">
       <%= render :file=>Vanity.template("_metric"), :locals=>{:id=>id, :metric=>metric} %>
-      <%= render :file=>Vanity.template("_metric"), :locals=>{:id=>id, :metric=>metric} %>
     </li>
   <% end %>
 </ul>


### PR DESCRIPTION
For some reason in the metrics partial you render the metric view twice. This is a one line commit that updates that to be a single render.
