### PR TITLE
Changes for Postgresql

### DIFF
--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -49,7 +49,7 @@ module Vanity
               t.integer :alternative
               t.integer :conversions
             end
-            connection.add_index :vanity_conversions, [:vanity_experiment_id, :alternative]
+            connection.add_index :vanity_conversions, [:vanity_experiment_id, :alternative], :name => "by_experiment_id_and_alternative"
 
             connection.create_table :vanity_participants do |t|
               t.string :experiment_id
@@ -59,10 +59,10 @@ module Vanity
               t.integer :converted
             end
             connection.add_index :vanity_participants, [:experiment_id]
-            connection.add_index :vanity_participants, [:experiment_id, :identity]
-            connection.add_index :vanity_participants, [:experiment_id, :shown]
-            connection.add_index :vanity_participants, [:experiment_id, :seen]
-            connection.add_index :vanity_participants, [:experiment_id, :converted]
+            connection.add_index :vanity_participants, [:experiment_id, :identity], :name => "by_experiment_id_and_identity"
+            connection.add_index :vanity_participants, [:experiment_id, :shown], :name => "by_experiment_id_and_shown"
+            connection.add_index :vanity_participants, [:experiment_id, :seen], :name => "by_experiment_id_and_seen"
+            connection.add_index :vanity_participants, [:experiment_id, :converted], :name => "by_experiment_id_and_converted"
 
             VanitySchema.create(:version => 1)
           end
@@ -124,7 +124,7 @@ module Vanity
         def self.retrieve(experiment, identity, create = true, update_with = nil)
           record = VanityParticipant.first(
                   :conditions =>
-                          {:experiment_id => experiment.to_s, :identity => identity})
+                          {:experiment_id => experiment.to_s, :identity => identity.to_s})
 
           if record
             record.update_attributes(update_with) if update_with
@@ -185,7 +185,7 @@ module Vanity
         dates = (from.to_date..to.to_date).map(&:to_s)
         conditions = [connection.quote_column_name('date') + ' IN (?)', dates]
         order = "#{connection.quote_column_name('date')}"
-        select = "sum(#{connection.quote_column_name('value')}) value, #{connection.quote_column_name('date')}"
+        select = "sum(#{connection.quote_column_name('value')}) AS value, #{connection.quote_column_name('date')}"
         group_by = "#{connection.quote_column_name('date')}"
 
         values = record.vanity_metric_values.all(

--- a/lib/vanity/templates/_experiment.erb
+++ b/lib/vanity/templates/_experiment.erb
@@ -1,5 +1,5 @@
 <h3><%=vanity_h experiment.name %> <span class="type">(<%= experiment.class.friendly_name %>)</span></h3>
-<%= experiment.description.to_s.split(/\n\s*\n/).map { |para| vanity_html_safe(%{<p class="description">#{vanity_h para}</p>}) }.join %>
+<%= experiment.description.to_s.split(/\n\s*\n/).map { |para| vanity_html_safe(%{<p class="description">#{vanity_h para}</p>}) }.join.html_safe %>
 <%= render :file => Vanity.template("_" + experiment.type), :locals => {:experiment => experiment} %>
 <p class="meta">Started <%= experiment.created_at.strftime("%a, %b %d") %>
   <%= " | Completed #{experiment.completed_at.strftime("%a, %b %d")}" unless experiment.active? %></p>


### PR DESCRIPTION
I ran into a few problems when using the active_record adapter and a Postgresql database with Vanity:
1. It complained that the index names generated by add_index were too long, so I gave them shorter names.
2. There were two SQL errors (comparing an int to a varchar column, no "as" on a column alias).

Finally, there was some auto-escaped text in the experiment template that I marked as html_safe. 
