### PR TITLE
Fix for metrics on rails 3 models

### DIFF
--- a/lib/vanity/metric/active_record.rb
+++ b/lib/vanity/metric/active_record.rb
@@ -58,7 +58,7 @@ module Vanity
         query = { :conditions=>{ @ar_timestamp=>(sdate.to_time...(edate + 1).to_time) },
                   :group=>"date(#{@ar_scoped.connection.quote_column_name @ar_timestamp})" }
         grouped = @ar_column ? @ar_scoped.send(@ar_aggregate, @ar_column, query) : @ar_scoped.count(query)
-        (sdate..edate).inject([]) { |ordered, date| ordered << (grouped[date.to_s] || 0) }
+        (sdate..edate).inject([]) { |ordered, date| ordered << (grouped[date] || 0) }
       end
 
       # This track! method stores nothing, but calls the hooks.


### PR DESCRIPTION
Don't cast date to string on Metric::ActiveRecord#values as the grouped result contains Date objects

When using a metric like

<pre>
metric "Signup (Activation)" do
    description "Measures how many people signed up for our awesome service."
    model User
end
</pre>

on rails 3, the query: 

SELECT COUNT(*) AS count_all, date(created_at) AS date_created_at FROM users WHERE (users.created_at >= '2011-01-24 03:00:00' AND users.created_at < '2011-04-24 03:00:00') GROUP BY date(created_at);

returns

<pre>
+-----------+-----------------+
| count_all | date_created_at |
+-----------+-----------------+
|         1 | 2011-02-21      |
|         1 | 2011-02-25      |
|         2 | 2011-03-11      |
|         3 | 2011-03-17      |
|         1 | 2011-03-24      |
|         2 | 2011-03-31      |
|         1 | 2011-04-09      |
|         1 | 2011-04-13      |
|         3 | 2011-04-23      |
+-----------+-----------------+
</pre>


But when parsing it in
Vanity::Metric.data(metric)
I get:

<pre>
[[Mon, 24 Jan 2011, 0], [Tue, 25 Jan 2011, 0], [Wed, 26 Jan 2011, 0], [Thu, 27 Jan 2011, 0], [Fri, 28 Jan 2011, 0], [Sat, 29 Jan 2011, 0], [Sun, 30 Jan 2011, 0], [Mon, 31 Jan 2011, 0], [Tue, 01 Feb 2011, 0], [Wed, 02 Feb 2011, 0], [Thu, 03 Feb 2011, 0], [Fri, 04 Feb 2011, 0], [Sat, 05 Feb 2011, 0], [Sun, 06 Feb 2011, 0], [Mon, 07 Feb 2011, 0], [Tue, 08 Feb 2011, 0], [Wed, 09 Feb 2011, 0], [Thu, 10 Feb 2011, 0], [Fri, 11 Feb 2011, 0], [Sat, 12 Feb 2011, 0], [Sun, 13 Feb 2011, 0], [Mon, 14 Feb 2011, 0], [Tue, 15 Feb 2011, 0], [Wed, 16 Feb 2011, 0], [Thu, 17 Feb 2011, 0], [Fri, 18 Feb 2011, 0], [Sat, 19 Feb 2011, 0], [Sun, 20 Feb 2011, 0], [Mon, 21 Feb 2011, 0], [Tue, 22 Feb 2011, 0], [Wed, 23 Feb 2011, 0], [Thu, 24 Feb 2011, 0], [Fri, 25 Feb 2011, 0], [Sat, 26 Feb 2011, 0], [Sun, 27 Feb 2011, 0], [Mon, 28 Feb 2011, 0], [Tue, 01 Mar 2011, 0], [Wed, 02 Mar 2011, 0], [Thu, 03 Mar 2011, 0], [Fri, 04 Mar 2011, 0], [Sat, 05 Mar 2011, 0], [Sun, 06 Mar 2011, 0], [Mon, 07 Mar 2011, 0], [Tue, 08 Mar 2011, 0], [Wed, 09 Mar 2011, 0], [Thu, 10 Mar 2011, 0], [Fri, 11 Mar 2011, 0], [Sat, 12 Mar 2011, 0], [Sun, 13 Mar 2011, 0], [Mon, 14 Mar 2011, 0], [Tue, 15 Mar 2011, 0], [Wed, 16 Mar 2011, 0], [Thu, 17 Mar 2011, 0], [Fri, 18 Mar 2011, 0], [Sat, 19 Mar 2011, 0], [Sun, 20 Mar 2011, 0], [Mon, 21 Mar 2011, 0], [Tue, 22 Mar 2011, 0], [Wed, 23 Mar 2011, 0], [Thu, 24 Mar 2011, 0], [Fri, 25 Mar 2011, 0], [Sat, 26 Mar 2011, 0], [Sun, 27 Mar 2011, 0], [Mon, 28 Mar 2011, 0], [Tue, 29 Mar 2011, 0], [Wed, 30 Mar 2011, 0], [Thu, 31 Mar 2011, 0], [Fri, 01 Apr 2011, 0], [Sat, 02 Apr 2011, 0], [Sun, 03 Apr 2011, 0], [Mon, 04 Apr 2011, 0], [Tue, 05 Apr 2011, 0], [Wed, 06 Apr 2011, 0], [Thu, 07 Apr 2011, 0], [Fri, 08 Apr 2011, 0], [Sat, 09 Apr 2011, 0], [Sun, 10 Apr 2011, 0], [Mon, 11 Apr 2011, 0], [Tue, 12 Apr 2011, 0], [Wed, 13 Apr 2011, 0], [Thu, 14 Apr 2011, 0], [Fri, 15 Apr 2011, 0], [Sat, 16 Apr 2011, 0], [Sun, 17 Apr 2011, 0], [Mon, 18 Apr 2011, 0], [Tue, 19 Apr 2011, 0], [Wed, 20 Apr 2011, 0], [Thu, 21 Apr 2011, 0], [Fri, 22 Apr 2011, 0], [Sat, 23 Apr 2011, 0]] 
</pre>


That's arrays with date objects and the count, but when doing the query it's matching with string dates, so it's always nil and it gets the fallback to 0 ( || 0 ).

This commit attempts to fix that.
