### PR TITLE
Visitor aliasing

### DIFF
--- a/lib/vanity/adapters/abstract_adapter.rb
+++ b/lib/vanity/adapters/abstract_adapter.rb
@@ -83,6 +83,14 @@ module Vanity
         fail "Not implemented"
       end 
 
+      def ab_canonical_identity(experiment, identity)
+        fail "Not implemented"
+      end
+
+      def ab_alias_participant(experiment, canonical_identity, new_identity)
+        fail "Not implemented"
+      end
+
       # Pick particular alternative (by index) to show to this particular
       # participant (by identity).
       def ab_show(experiment, identity, alternative)

--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -249,6 +249,14 @@ module Vanity
         }
       end
 
+      def ab_canonical_identity(experiment, identity)
+        fail "Not implemented"
+      end
+
+      def ab_alias_participant(experiment, canonical_identity, new_identity)
+        fail "Not implemented"
+      end
+
       # Pick particular alternative (by index) to show to this particular
       # participant (by identity).
       def ab_show(experiment, identity, alternative)

--- a/lib/vanity/adapters/mock_adapter.rb
+++ b/lib/vanity/adapters/mock_adapter.rb
@@ -101,6 +101,18 @@ module Vanity
           :conversions  => alt[:conversions] || 0 }
       end
 
+      def ab_canonical_identity(experiment, identity)
+        @experiments[experiment] ||= {}
+        @experiments[experiment][:identities] ||= {}
+        @experiments[experiment][:identities][identity]
+      end
+
+      def ab_alias_participant(experiment, canonical_identity, new_identity)
+        @experiments[experiment] ||= {}
+        @experiments[experiment][:identities] ||= {}
+        @experiments[experiment][:identities][new_identity] = canonical_identity
+      end
+
       def ab_show(experiment, identity, alternative)
         @experiments[experiment] ||= {}
         @experiments[experiment][:showing] ||= {}

--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -107,6 +107,14 @@ module Vanity
           :conversions  => @experiments["#{experiment}:alts:#{alternative}:conversions"].to_i }
       end
 
+      def ab_canonical_identity(experiment, identity)
+        @experiments.get("#{experiment}:identities:#{identity}:canonical") || identity
+      end
+
+      def ab_alias_participant(experiment, canonical_identity, new_identity)
+        @experiments.set "#{experiment}:identities:#{new_identity}:canonical", canonical_identity
+      end
+
       def ab_show(experiment, identity, alternative)
         @experiments["#{experiment}:participant:#{identity}:show"] = alternative
       end

--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -264,6 +264,9 @@ module Vanity
         end
       end
 
+      def alias_participant(canonical_id, new_id)
+        connection.ab_alias_participant(@id, canonical_id, new_id)
+      end
 
       # -- Reporting --
 
@@ -440,6 +443,12 @@ module Vanity
       #   -- Reid Hoffman, founder of LinkedIn
 
     protected
+
+      def identity
+        ident = super
+        ident = (connection.ab_canonical_identity(@id, ident) || ident) if connection.active?
+        ident
+      end
 
       # Used for testing.
       def fake(values)

--- a/lib/vanity/experiment/base.rb
+++ b/lib/vanity/experiment/base.rb
@@ -111,6 +111,10 @@ module Vanity
         @identify_block = block
       end
 
+      def alias_participant(canonical_id, new_id)
+        # Noop in the base class
+      end
+
 
       # -- Reporting --
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -86,7 +86,7 @@ class Test::Unit::TestCase
 
   def not_collecting!
     Vanity.playground.collecting = false
-    Vanity.playground.stubs(:connection).returns(stub(:flushdb=>nil))
+    Vanity.playground.stubs(:connection).returns(stub(:flushdb=>nil, :'active?'=>false))
   end
 
   def teardown


### PR DESCRIPTION
Hey Assaf-  
I decided to implement aliasing after all... turns out it wasn't too hard to get working and I wanted support for it.  (for everyone else, a full description culled from my email w/ Assaf is below)

All tests pass (rake test:all), but I haven't implement the active-record adapter because there weren't any tests for it.  I added two new tests to cover the aliasing functionality.

Not sure if you really want to merge this, but I'm offering it up anyway.  Performance is definitely worse than without aliasing, because an extra backend lookup must be made before selecting any alternative or calling any backend that uses the vanity identity.  I haven't done any performance benchmarking (for our app the difference will be completely irrelevant), but I didn't notice a huge difference in the speed of the test runs.

This branch closes #10.
## Visitor Aliasing Functionality

We are currently running a test that spans the user-account creation step in our funnel. So, at the beginning of the test visitors are identified by Vanity using the vanity_id cookie... and once they log in, they are assigned a new vanity_identity based on the id of the current_user. (use_vanity :current_user)

The problem is that Vanity doesn't have any sort of visitor aliasing... so the same visitor is often re-assigned to a different A/B test alternative at the point that they are logged-in (because the vanity_identity changes at that point). Obviously this wreaks havoc on our test data and makes it unusable, so we need to come up with a fix.

Some other folks have encountered the same problem here: https://github.com/assaf/vanity/issues/10

KISSMetrics does a really nice job of handling this, read more here: http://support.kissmetrics.com/apis/common-methods#alias
