### PR TITLE
fix choose mode in test mode

### DIFF
--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -199,6 +199,7 @@ module Vanity
           identity = identity()
           @showing ||= {}
           @showing[identity] ||= alternative_for(identity)
+          index = @showing[identity]
         end
         alternatives[index.to_i]
       end


### PR DESCRIPTION
fix returning correct experiment when in test mode and manually set via #chooses
