### PR TITLE
don't round the conversion rate before using it

### DIFF
--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -44,9 +44,9 @@ module Vanity
       # Difference from least performing alternative. Populated by AbTest#score.
       attr_accessor :difference
 
-      # Conversion rate calculated as converted/participants, rounded to 3 places.
+      # Conversion rate calculated as converted/participants
       def conversion_rate
-        @conversion_rate ||= (participants > 0 ? (converted.to_f/participants.to_f * 1000).round / 1000.0 : 0.0)
+        @conversion_rate ||= (participants > 0 ? converted.to_f/participants.to_f  : 0.0)
       end
 
       # The measure we use to order (sort) alternatives and decide which one is better (by calculating z-score).

--- a/test/experiment/ab_test.rb
+++ b/test/experiment/ab_test.rb
@@ -339,7 +339,7 @@ class AbTestTest < ActionController::TestCase
     fake :abcd, :a=>[182, 35], :b=>[180, 45], :c=>[189,28], :d=>[188, 61]
 
     z_scores = experiment(:abcd).score.alts.map { |alt| "%.2f" % alt.z_score }
-    assert_equal %w{-1.33 0.00 -2.47 1.58}, z_scores
+    assert_equal %w{-1.33 0.00 -2.46 1.58}, z_scores
     probabilities = experiment(:abcd).score.alts.map(&:probability)
     assert_equal [90, 0, 99, 90], probabilities
 
@@ -481,7 +481,7 @@ Option C did not convert.
 
     assert_equal <<-TEXT, experiment(:abcd).conclusion.join("\n") << "\n"
 There are 374 participants in this experiment.
-The best choice is option D: it converted at 32.4%.
+The best choice is option D: it converted at 32.4% (1% better than option B).
 This result is not statistically significant, suggest you continue this experiment.
 Option B converted at 32.3%.
 Option A did not convert.


### PR DESCRIPTION
it affects the test results, making them less accurate
