### PR TITLE
specify redis connection string as value for adapter. Do not use host, or

### DIFF
--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -154,15 +154,13 @@ $stdout << Vanity.playground.connection
     RB
   end
 
-  def test_connection_from_yaml
+  def test_connection_from_yaml_with_redis_connection_string
     FileUtils.mkpath "tmp/config"
     ENV["RAILS_ENV"] = "production"
     File.open("tmp/config/vanity.yml", "w") do |io|
       io.write <<-YML
 production:
-  adapter: redis
-  host: somehost
-  database: 15
+  adapter: "redis://somehost:6379/15"
       YML
     end
     assert_equal "redis://somehost:6379/15", load_rails(<<-RB)
@@ -280,14 +278,6 @@ $stdout << Vanity.playground.collecting?
     assert_equal "true", load_rails(<<-RB, "development")
 Vanity.playground.collecting = true
 initializer.after_initialize
-$stdout << Vanity.playground.collecting?
-    RB
-  end
-
-  def test_collection_false_after_test!
-    assert_equal "false", load_rails(<<-RB, "production")
-initializer.after_initialize
-Vanity.playground.test!
 $stdout << Vanity.playground.collecting?
     RB
   end


### PR DESCRIPTION
specify redis connection string as value for adapter. Do not use host, or database options. Remove test for deprecated test! method to remove deprecation warning in test output.

Is this the right format for the vanity.yml config file? Basically using the adapter param with a value of the redis connection string? Seems to work in this updated test and with vanity 1.5.3 in a rails app, but it is pretty confusing.  I would love to see some of the deprecation code removed, it really makes things difficult to track down and some of the deprecated code is 1yr old plus.
