### PR TITLE
Add bson_ext to Gemfile to load C extension for mongodb ruby driver, and 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
   gem "garb"
   gem "mocha"
   gem "mongo"
+  gem "bson_ext"
   gem "mysql"
   gem "passenger"
   gem "rails", "2.3.8"


### PR DESCRIPTION
Add bson_ext to Gemfile to load C extension for mongodb ruby driver, and prevent Notice messages as the tests run.
