### PR TITLE
Update redis-namespace dependency to 1.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     vanity (1.6.0)
       redis (~> 2.0)
-      redis-namespace (~> 0.7)
+      redis-namespace (~> 1.0.0)
 
 GEM
   remote: http://rubygems.org/
@@ -58,7 +58,7 @@ GEM
       rake (>= 0.8.3)
     rake (0.8.7)
     redis (2.2.1)
-    redis-namespace (0.10.0)
+    redis-namespace (1.0.3)
       redis (< 3.0.0)
     shoulda (2.11.3)
     syntax (1.0.0)

--- a/vanity.gemspec
+++ b/vanity.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.8.7'
   spec.add_dependency "redis", "~>2.0"
-  spec.add_dependency "redis-namespace", "~>0.7"
+  spec.add_dependency "redis-namespace", "~>1.0.0"
 end


### PR DESCRIPTION
Tests pass and participants/goals seem to be tracked with new version of redis-namespace.

Fixes issue #53
