### PR TITLE
Fix hung passenger processes

### DIFF
--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -28,7 +28,7 @@ module Vanity
       def disconnect!
         if redis
           begin
-            redis.quit
+            redis.client.disconnect
           rescue Exception => e
             warn("Error while disconnecting from redis: #{e.message}")
           end

--- a/test/adapters/redis_adapter_test.rb
+++ b/test/adapters/redis_adapter_test.rb
@@ -6,7 +6,7 @@ class RedisAdapterTest < Test::Unit::TestCase
       assert_nothing_raised do
         Redis.any_instance.stubs(:connect!)
         mocked_redis = stub("Redis")
-        mocked_redis.expects(:quit).raises(RuntimeError)
+        mocked_redis.expects(:client).raises(RuntimeError)
         redis_adapter = Vanity::Adapters::RedisAdapter.new({})
         redis_adapter.expects(:warn).with("Error while disconnecting from redis: RuntimeError")
         redis_adapter.stubs(:redis).returns(mocked_redis)


### PR DESCRIPTION
We had a situation where, from the minute we rolled out Vanity we had passenger processes getting hung. 3 workers per server would be serving requests but the rest would be hung in Sessions: 1 Processed: 0. It took us a long while to track down, but we eventually traced it to the Passenger fork hook callback down to the redis adapter disconnect call calling into the redis client gem calling quit. The server would never respond, the call would never timeout, and the process hung until it received a some sort of unix signal.

Redis#quit is a polite exit, it writes to the server to let it know it is going to close the connection after the last message, but when dealing with forking servers you need a more direct disconnect since the current process no longer controls that connection.

Details of the setup: Rails 2.3.12, Passenger 3.0.8, Ruby Enterprise Edition 2011.03.
