### PR TITLE
fix issue with vanity_js not referencing the exact file name

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -209,7 +209,7 @@ module Vanity
       def vanity_js
         return if @_vanity_experiments.nil?
         javascript_tag do
-          render :file=>Vanity.template("vanity.js.erb")
+          render :file=>Vanity.template("_vanity.js.erb")
         end
       end
 


### PR DESCRIPTION
the vanity_js helper was rendering vanity.js instead of _vanity.js.erb. 
