### PR TITLE
I changed Playground#reconnect! to use an existing connection.

### DIFF
--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -242,6 +242,7 @@ module Vanity
     #
     # @since 1.4.0 
     def establish_connection(spec = nil)
+      @spec = spec
       disconnect! if @adapter
       case spec
       when nil
@@ -309,7 +310,7 @@ module Vanity
     #
     # @since 1.3.0
     def reconnect!
-      establish_connection
+      establish_connection(@spec)
     end
 
     # Deprecated. Use Vanity.playground.collecting = true/false instead.  Under

--- a/test/playground_test.rb
+++ b/test/playground_test.rb
@@ -17,4 +17,10 @@ class PlaygroundTest < Test::Unit::TestCase
     assert_equal Vanity.playground.add_participant_path, Vanity::Playground::DEFAULT_ADD_PARTICIPANT_PATH
   end
 
+  def test_reconnects_with_existing_connection
+    Vanity.playground.establish_connection "mock:/"
+    Vanity.playground.reconnect!
+    assert_equal Vanity.playground.connection.to_s, "mock:/"
+  end
+
 end


### PR DESCRIPTION
When our application was reconnecting to a remote Redis server, it would try and connect to localhost instead. I think the test case and patch are pretty self explanatory--let me know if you have any questions/comments.
