### PR TITLE
Fix broken view specs when vanity is loaded

### DIFF
--- a/lib/vanity.rb
+++ b/lib/vanity.rb
@@ -33,4 +33,4 @@ require "vanity/adapters/mock_adapter"
 require "vanity/playground"
 require "vanity/helpers"
 # Integration with various frameworks.
-require "vanity/frameworks/rails" if defined?(Rails)
+require "vanity/frameworks"

--- a/lib/vanity/frameworks.rb
+++ b/lib/vanity/frameworks.rb
@@ -1,0 +1,16 @@
+# Automatically configure Vanity.
+if defined?(Rails)
+  if Rails.const_defined?(:Railtie) # Rails 3
+    class Plugin < Rails::Railtie # :nodoc:
+      initializer "vanity.require" do |app|
+        require 'vanity/frameworks/rails'  
+        Vanity::Rails.load!
+      end
+    end
+  else
+    Rails.configuration.after_initialize do
+      require 'vanity/frameworks/rails'  
+      Vanity::Rails.load!
+    end
+  end
+end

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -304,22 +304,6 @@ if defined?(ActionMailer)
   end
 end
 
-# Automatically configure Vanity.
-if defined?(Rails)
-  if Rails.const_defined?(:Railtie) # Rails 3
-    class Plugin < Rails::Railtie # :nodoc:
-      initializer "vanity.require" do |app|
-        Vanity::Rails.load!
-      end
-    end
-  else
-    Rails.configuration.after_initialize do
-      Vanity::Rails.load!
-    end
-  end
-end
-
-
 # Reconnect whenever we fork under Passenger.
 if defined?(PhusionPassenger)
   PhusionPassenger.on_event(:starting_worker_process) do |forked|


### PR DESCRIPTION
When vanity is loaded, views specs suddenly start breaking.

This happens because `ActionController::TestCase` gets loaded before the application itself. That way `ActionController::TestCase` does not get the opportunity to define all helpers that the application will use. In the end, there are less helpers available in the spec.

This can be solved by rewriting the Rails extension to do its thing after the application has loaded (as it should). I have just move the railtie around and tweaked it to load later.

This also fixes #75.

Cheers!
