### PR TITLE
force render to treat path to template as absolute

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -253,15 +253,12 @@ module Vanity
       end
 
       def add_participant
-        STDOUT.puts "add_participant called"
-
       	if params[:e].nil? || params[:e].empty?
       	  render :status => 404, :nothing => true
       	  return
       	end
         exp = Vanity.playground.experiment(params[:e].to_sym)
         exp.chooses(exp.alternatives[params[:a].to_i].value)
-        STDOUT.puts "adding participant for #{params[:e]}: #{params[:a]}"
         render :status => 200, :nothing => true
       end
     end


### PR DESCRIPTION
I don't know if this was a problem with my local setup, but I kept getting "missing partial" errors when calling vanity_js. Looked like the render function was messing with the template path, this change fixed it for me.
