### PR TITLE
adding ability to set an on_assignment function

### DIFF
--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -201,6 +201,12 @@ module Vanity
             index = connection.ab_showing(@id, identity)
             unless index
               index = alternative_for(identity)
+              # if we have an on_assignment block, make sure we both store the assignment and call the on_assignment block
+              if @on_assignment_block
+                assignment = alternatives[index.to_i]
+                connection.ab_show(@id, identity, index.to_i)
+                @on_assignment_block.call(Vanity.context, identity, assignment, self)
+              end
               if !@playground.using_js?
                 connection.ab_add_participant @id, index, identity
                 check_completion!

--- a/lib/vanity/experiment/base.rb
+++ b/lib/vanity/experiment/base.rb
@@ -69,6 +69,7 @@ module Vanity
         @id, @name = id.to_sym, name
         @options = options || {}
         @identify_block = method(:default_identify)
+        @on_assignment_block = nil
       end
 
       # Human readable experiment name (first argument you pass when creating a
@@ -113,6 +114,19 @@ module Vanity
         @identify_block = block
       end
 
+      # Defines any additional actions to take when a new assignment is made for the current experiment
+      #
+      # For example, if you want to use the rails default logger to log whenever an assignment is made:
+      #   ab_test "Project widget" do
+      #     alternatives :small, :medium, :large
+      #     on_assignment do |controller, identity, assignment|
+      #       controller.logger.info "made a split test assignment for #{experiment.name}: #{identity} => #{assignment}"
+      #     end
+      #   end
+      def on_assignment(&block)
+        fail "Missing block" unless block
+        @on_assignment_block = block
+      end
 
       # -- Reporting --
 

--- a/test/experiment/ab_test.rb
+++ b/test/experiment/ab_test.rb
@@ -137,6 +137,33 @@ class AbTestTest < ActionController::TestCase
     assert_equal 0, alts.map(&:participants).sum
   end
 
+  # -- on_assignment --
+
+  def test_calls_on_assignment_on_new_assignment
+    on_assignment_called_times = 0
+    new_ab_test :foobar do
+      alternatives "foo", "bar"
+      identify { "6e98ec" }
+      metrics :coolness
+      on_assignment { on_assignment_called_times = on_assignment_called_times+1 }
+    end
+    2.times { experiment(:foobar).choose }
+    assert_equal on_assignment_called_times, 1
+  end
+
+  def test_returns_the_same_alternative_consistently_when_on_assignment_is_set
+    new_ab_test :foobar do
+      alternatives "foo", "bar"
+      identify { "6e98ec" }
+      on_assignment {}
+      metrics :coolness
+    end
+    assert value = experiment(:foobar).choose.value
+    assert_match /foo|bar/, value
+    1000.times do
+      assert_equal value, experiment(:foobar).choose.value
+    end
+  end
 
   # -- Running experiment --
 


### PR DESCRIPTION
which is called when an identity is given an assignment in ab_test -- this is intended mainly for tying into external logging systems (I'm using it to log the split test assignment to our central logging system)
