### PR TITLE
we should never enable js for email testing

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -182,12 +182,12 @@ module Vanity
       #     <%= count %> features to choose from!
       #   <% end %>
       def ab_test(name, &block)
-        if defined?(ActionMailer) && Vanity.context < ActionMailer::Base
+        value = if defined?(ActionMailer) && Vanity.context < ActionMailer::Base
           Vanity.playground.without_js do
-            value = setup_experiment(name)
+            setup_experiment(name)
           end
         else
-          value = setup_experiment(name)
+          setup_experiment(name)
         end
  
         if block

--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -132,8 +132,9 @@ module Vanity
     def without_js(&block)
       original = @use_js
       @use_js = false
-      block.call
+      value = block.call
       @use_js = original
+      value
     end
 
 


### PR DESCRIPTION
Bug report:

If `Vanity.use_js!` is enabled, email a/b testing never adds any participant.

The fix: add a helper that disables the js participant adding that wraps the js.

Note:

This isn't thread safe. I don't think I know vanity well enough to know if turning `@use_js` in the playground into a thread local variable would be a bad thing (so I'd love some feedback on this).
