### PR TITLE
Fixes a MassAssignmentSecurity error, Rails 3.2.12

### DIFF
--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -32,6 +32,8 @@ module Vanity
 
       # Metric value
       class VanityMetricValue < VanityRecord
+        attr_accessible :date, :index, :value
+
         self.table_name = :vanity_metric_values
         belongs_to :vanity_metric
       end


### PR DESCRIPTION
When calling 
    track! MyMetric

I was getting a 500 under Rails 3.2.12, vanity 1.8.

Completed 500 Internal Server Error in 5ms

ActiveModel::MassAssignmentSecurity::Error (Can't mass-assign protected attributes: date, index, value)

I don't get the 500 any more, after this patch.
