### PR TITLE
vanity_experiments helper returns {} instead of nil when there are no experiments on the page

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -211,7 +211,7 @@ module Vanity
       end
 
       def vanity_js
-        return if @_vanity_experiments.nil?
+        return if @_vanity_experiments.nil? || @_vanity_experiments.empty?
         javascript_tag do
           render :file => Vanity.template("_vanity.js.erb")
         end
@@ -237,16 +237,13 @@ module Vanity
       #
       # @example Render some info about each active experiment in development mode
       #   <% if Rails.env.development? %>
-      #     <% experiments = vanity_experiments %>
-      #     <% unless experiments.nil? %>
-      #       <% experiments.each do |name, alternative| %>
-      #         <span>Participating in <%= name %>, seeing <%= alternative %>:<%= alternative.value %> </span>
-      #       <% end %>
+      #     <% vanity_experiments.each do |name, alternative| %>
+      #       <span>Participating in <%= name %>, seeing <%= alternative %>:<%= alternative.value %> </span>
       #     <% end %>
       #   <% end %>
       # @example Push experiment values into javascript for use there
       #   <% experiments = vanity_experiments %>
-      #   <% unless experiments.nil? %>
+      #   <% unless experiments.empty? %>
       #     <script>
       #       <% experiments.each do |name, alternative| %>
       #         myAbTests.<%= name.to_s.camelize(:lower) %> = '<%= alternative.value %>';
@@ -254,11 +251,13 @@ module Vanity
       #     </script>
       #   <% end %>
       def vanity_experiments
-        return if @_vanity_experiments.nil?
+        @_vanity_experiments ||= {}
         experiments = {}
+
         @_vanity_experiments.each do |name, alternative|
           experiments[name] = alternative.clone
         end
+
         return experiments
       end
     end

--- a/lib/vanity/templates/_vanity.js.erb
+++ b/lib/vanity/templates/_vanity.js.erb
@@ -1,20 +1,16 @@
-<% unless @_vanity_experiments.empty? %>
-  var httpRequest;
-  <%
-    @_vanity_experiments.each do |name, alternative| 
-  %>
-    var params = "e=<%= name %>&a=<%= alternative.id %>&authenticity_token=" + encodeURIComponent("<%= form_authenticity_token %>");
-    if (window.XMLHttpRequest) { // Mozilla, Safari, ...
-      httpRequest = new XMLHttpRequest();
-    } else if (window.ActiveXObject) { // IE
-      try { httpRequest = new ActiveXObject("Msxml2.XMLHTTP"); }
-      catch (e) { }
-    }
-    if (httpRequest) {
-      httpRequest.open('POST', "<%= Vanity.playground.add_participant_path %>", true);
-      httpRequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-      httpRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-      httpRequest.send(params);
-    }
-  <% end %>
+var httpRequest;
+<% @_vanity_experiments.each do |name, alternative| %>
+  var params = "e=<%= name %>&a=<%= alternative.id %>&authenticity_token=" + encodeURIComponent("<%= form_authenticity_token %>");
+  if (window.XMLHttpRequest) { // Mozilla, Safari, ...
+    httpRequest = new XMLHttpRequest();
+  } else if (window.ActiveXObject) { // IE
+    try { httpRequest = new ActiveXObject("Msxml2.XMLHTTP"); }
+    catch (e) { }
+  }
+  if (httpRequest) {
+    httpRequest.open('POST', "<%= Vanity.playground.add_participant_path %>", true);
+    httpRequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+    httpRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+    httpRequest.send(params);
+  }
 <% end %>

--- a/test/rails_helper_test.rb
+++ b/test/rails_helper_test.rb
@@ -52,8 +52,8 @@ class RailsHelperTest < ActionView::TestCase
     assert_equal vanity_experiments.keys.length, 1
   end
 
-  def test_vanity_experiments_returns_nil_when_no_experiments
-    assert_nil vanity_experiments
+  def test_vanity_experiments_returns_empty_hash_when_no_experiments
+    assert_equal vanity_experiments, {}
   end
 
 end


### PR DESCRIPTION
@phillbaker As we discussed, changed the return value of vanity_experiments to an empty hash when there are no experiments on the page.  Makes it easier/more intuitive not to have to write conditionals protecting yourself from a nil return.
