### PR TITLE
Get rid of deprecation warning

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -213,7 +213,11 @@ module Vanity
       def vanity_js
         return if @_vanity_experiments.nil? || @_vanity_experiments.empty?
         javascript_tag do
-          render :file => Vanity.template("_vanity.js.erb")
+          if (Rails.version =~ /^2.3/)
+            render :file => Vanity.template("_vanity.js.erb")
+         else
+            render :file => Vanity.template("_vanity"), :formats => :js, :handlers => ['erb']
+         end
         end
       end
 


### PR DESCRIPTION
Should silence the warning here: https://github.com/assaf/vanity/issues/132
