### PR TITLE
Switch default collection setting to be on for all environments.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -125,10 +125,6 @@ The controller should look like:
     include Vanity::Rails::Dashboard
   end
 
-NOTE: By default, Vanity turns collection off in development mode. To turn it on, in <code>config/environments/development.rb</code> add:
-
-  Vanity.playground.collecting = true
-
 == Registering participants with Javascript
 
 If robots or spiders make up a significant portion of your sites traffic they can affect your conversion rate. Vanity can optionally add participants to the experiments using asynchronous javascript callbacks, which will keep almost all robots out. To set this up simply do the following:

--- a/doc/configuring.textile
+++ b/doc/configuring.textile
@@ -11,6 +11,8 @@ Database connection information is loaded from @config/vanity.yml@, based on the
 development:
   adapter: redis
   connection: redis://localhost:6379/0
+test:
+  collecting: false
 production:
   adapter: mongodb
   database: analytics
@@ -23,10 +25,6 @@ The available database adapters are:
 * +redis+ -- This adapter is used by default. Available options are connection and password. host, port, database (defaults to 0) options are available, but deprecated.
 * +mongodb+ -- Available options are host, port, database (defaults to "vanity"), username and password.
 * +active_record+ -- Uses existing ActiveRecord configuration, by you can over-ride by supplying different options. To pick different underlying adapter, set +active_record_adapter+.
-
-You want Vanity to collect information (metrics, experiments, etc) in production, but there's no point collecting data in other environments. You can turn data collection on and off by setting @Vanity.playground.collecting@. Under Rails, collection is turned off in all environments expect production.
-
-You may want to turn data collection on for integration tests, depending on what you're testing. Also, you may need to turn it on if your development server runs more than one process, e.g. if you're using Passenger for development and want to use the Vanity console to pick a particular alternative in an A/B test.
 
 Available configuration options are:
 

--- a/doc/email.textile
+++ b/doc/email.textile
@@ -48,7 +48,7 @@ end
 Create an ActionMailer class, for example:
 
 <pre>
-class UserMailer < ActionMailer::Base 
+class UserMailer < ActionMailer::Base
   def invite_email(user)
     use_vanity_mailer user
     mail :to => user.email, :subject =>ab_test(:invite_subject)
@@ -125,5 +125,3 @@ A/B test your email content:
 </pre>
 
 Here we use the text from the "invite_text" experiment and then use the @vanity_track_url_for@ helper to add the identity and the metric to track into the url so that Vanity can track the click-throughs.
-
-Remember: By default, Vanity only collects data in production mode.

--- a/doc/rails.textile
+++ b/doc/rails.textile
@@ -45,7 +45,7 @@ class ApplicationController < ActionController::Base
 end
 </pre>
 
-This example assumes you have a @current_user@ controller method which will return a consistent value for each user. 
+This example assumes you have a @current_user@ controller method which will return a consistent value for each user.
 There are other ways to identify people as well, you can read more about the options in Managing Identity.
 
 h4. Configuring datastore
@@ -73,9 +73,9 @@ config.after_initialize do
 end
 </pre>
 
-h4. Enabling experiments outside of the production environment
+h4. Enabling/disable collection
 
-There's generally no need to collect metric and experiment data outside production environment.  Under Rails, Vanity turns collection on only if the environment name is "production". You can control this from @config/environments@ by setting @Vanity.playground.collecting@ to true/false. When collection is off, Vanity doesn't connect to the database server, so there's no need to set a database configuration for these environments.
+When collection is off, Vanity doesn't connect to the database server, so there's no need to set a database configuration for these environments.
 
 
 h3(#dashboard).  Dashboard
@@ -90,7 +90,7 @@ Create a new controller for Vanity:
 
 <pre>
 class VanityController < ApplicationController
-include Vanity::Rails::Dashboard
+  include Vanity::Rails::Dashboard
 end
 </pre>
 

--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -26,7 +26,7 @@ module Vanity
       options = Hash === args.last ? args.pop : {}
       # In the case of Rails, use the Rails logger and collect only for
       # production environment by default.
-      defaults = options[:rails] ? DEFAULTS.merge(:collecting => ::Rails.env.production?, :logger => ::Rails.logger) : DEFAULTS
+      defaults = options[:rails] ? DEFAULTS.merge(:collecting => true, :logger => ::Rails.logger) : DEFAULTS
       if config_file_exists?
         env = ENV["RACK_ENV"] || ENV["RAILS_ENV"] || "development"
         config = load_config_file[env]
@@ -417,9 +417,7 @@ module Vanity
       establish_connection(@spec)
     end
 
-    # Deprecated. Use Vanity.playground.collecting = true/false instead. Under
-    # Rails, collecting is true in production environment, false in all other
-    # environments, which is exactly what you want.
+    # Deprecated. Use Vanity.playground.collecting = true/false instead.
     def test!
       warn "Deprecated: use collecting = false instead"
       self.collecting = false

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -451,8 +451,8 @@ $stdout << Vanity.playground.collecting?
     RB
   end
 
-  def test_collection_false_in_development_by_default
-    assert_equal "false", load_rails("", <<-RB, "development")
+  def test_collection_true_in_development_by_default
+    assert_equal "true", load_rails("", <<-RB, "development")
 $stdout << Vanity.playground.collecting?
     RB
   end


### PR DESCRIPTION
- Closes #159.
- Includes documentation updates for code changes. /cc @assaf how can we update the docs at http://vanity.labnotes.org ?

This changes the settings established in v1.4.0 and fixed in 57cd3e9a. The motivation for this is:
- To avoid confusion/support issues like #24 and https://github.com/assaf/vanity/issues/80#issuecomment-2851962
- Make it easier to setup and try Vanity in development (offering proof of functionality), before deploying it to production
- Follow Ruby gems/Rails conventions: from a brief survey, it seems like other gems do _not_ turn off by default in development/test

Some of the hassle of setting up the datastore in development is mitigated by #11. An alternative to this PR might be to separate an "enabled" setting from "collecting" where `enabled=true, collecting=false` allows Vanity to show alternatives/function normally, but discards data.
