### PR TITLE
Allow posts in recommended route in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -104,7 +104,7 @@ To view metrics and experiment results with the dashboard in Rails 3 & Rails 4:
 
 In <code>config/routes.rb</code>, add:
 
-  match '/vanity(/:action(/:id(.:format)))', :controller => :vanity, :via => :get
+  match '/vanity(/:action(/:id(.:format)))', :controller => :vanity, :via => [:get, :post]
 
 Where the controller should looks like:
 


### PR DESCRIPTION
POSTs need to be supported in route to allow experiment option selection and experiment completion.
