### PR TITLE
Do not load vanity playground if vanity is disabled.

### DIFF
--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -207,6 +207,7 @@ module Vanity
     # Loads all metrics and experiments.  Rails calls this during
     # initialization.
     def load!
+      return unless Vanity::Autoconnect.playground_should_autoconnect?
       experiments
       metrics
     end


### PR DESCRIPTION
This is a necessary addition to https://github.com/assaf/vanity/commit/1cdafa27d0
This way you can still run "rake db:migrate" for example even if experiment exists
and is vanity is used in the application code.

I don't quite like this solution, will appreciate any hints on how to fix this the right way.
