### PR TITLE
Remove hardcoded dashboard layouts

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -66,6 +66,7 @@ Turn Vanity on, and pass a reference to a method that identifies a user. For exa
 
   class ApplicationController < ActionController::Base
     use_vanity :current_user
+    layout false  # exclude this if you want to use your application layout
   end
 
 For more information, please see the {identity documentation}[http://vanity.labnotes.org/identity.html].

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -284,11 +284,11 @@ module Vanity
         @experiments = Vanity.playground.experiments
         @experiments_persisted = Vanity.playground.experiments_persisted?
         @metrics = Vanity.playground.metrics
-        render :file=>Vanity.template("_report"), :content_type=>Mime::HTML, :layout=>false
+        render :file=>Vanity.template("_report"), :content_type=>Mime::HTML
       end
 
       def participant
-        render :file=>Vanity.template("_participant"), :locals=>{:participant_id => params[:id], :participant_info => Vanity.playground.participant_info(params[:id])}, :content_type=>Mime::HTML, :layout=>false
+        render :file=>Vanity.template("_participant"), :locals=>{:participant_id => params[:id], :participant_info => Vanity.playground.participant_info(params[:id])}, :content_type=>Mime::HTML
       end
 
       def complete


### PR DESCRIPTION
Got another one for you. It doesn't make sense that only 2 pages are rendered with `layout: false` and the others aren't (so when I click "Make permanent" on the experiment, the page suddenly renders with my application layout.) We could put `layout: false` on all of the render statements, but my proposed solution is just to remove them and let people define the layout in their VanityController, e.g. by putting `layout: false` in there (as I have done.) This is the most flexible solution that's consistent.
