### PR TITLE
Add Playground#request_filter for AbTest#choose(s).

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -7,7 +7,7 @@ module Vanity
       # Do this at the very end of initialization, allowing you to change
       # connection adapter, turn collection on/off, etc.
       ::Rails.configuration.after_initialize do
-	Vanity.playground.load! if Vanity.playground.connected?
+        Vanity.playground.load! if Vanity.playground.connected?
       end
     end
 
@@ -263,7 +263,8 @@ module Vanity
 
       def setup_experiment(name)
         @_vanity_experiments ||= {}
-        @_vanity_experiments[name] ||= Vanity.playground.experiment(name.to_sym).choose
+        request = respond_to?(:request) ? self.request : nil
+        @_vanity_experiments[name] ||= Vanity.playground.experiment(name.to_sym).choose(request)
         @_vanity_experiments[name].value
       end
 
@@ -317,7 +318,7 @@ module Vanity
           return
         end
         exp = Vanity.playground.experiment(params[:e].to_sym)
-        exp.chooses(exp.alternatives[params[:a].to_i].value)
+        exp.chooses(exp.alternatives[params[:a].to_i].value, request)
         render :status => 200, :nothing => true
       end
     end
@@ -339,18 +340,6 @@ if defined?(ActionController)
     extend Vanity::Rails::UseVanity
     include Vanity::Rails::Filters
     helper Vanity::Rails::Helpers
-  end
-
-  module ActionController
-    class TestCase
-      alias :setup_controller_request_and_response_without_vanity :setup_controller_request_and_response
-      # Sets Vanity.context to the current controller, so you can do things like:
-      #   experiment(:simple).chooses(:green)
-      def setup_controller_request_and_response
-        setup_controller_request_and_response_without_vanity
-        Vanity.context = @controller
-      end
-    end
   end
 end
 

--- a/lib/vanity/helpers.rb
+++ b/lib/vanity/helpers.rb
@@ -1,4 +1,4 @@
-module Vanity  
+module Vanity
   # Helper methods available on Object.
   #
   # @example From ERB template
@@ -17,7 +17,7 @@ module Vanity
   #     end
   #   end
   module Helpers
-    
+
     # This method returns one of the alternative values in the named A/B test.
     #
     # @example A/B two alternatives for a page
@@ -34,12 +34,14 @@ module Vanity
     #   end
     # @since 1.2.0
     def ab_test(name, &block)
+      # TODO refactor with Vanity::Rails::Helpers#ab_test
+      request = respond_to?(:request) ? self.request : nil
       if Vanity.playground.using_js?
         @_vanity_experiments ||= {}
-        @_vanity_experiments[name] ||= Vanity.playground.experiment(name).choose
+        @_vanity_experiments[name] ||= Vanity.playground.experiment(name).choose(request)
         value = @_vanity_experiments[name].value
       else
-        value = Vanity.playground.experiment(name).choose.value
+        value = Vanity.playground.experiment(name).choose(request).value
       end
 
       if block

--- a/test/playground_test.rb
+++ b/test/playground_test.rb
@@ -13,6 +13,28 @@ class PlaygroundTest < Test::Unit::TestCase
     assert Vanity.playground.using_js?
   end
 
+  def test_be_failover_on_datastore_error
+    assert !Vanity.playground.failover_on_datastore_error?
+    Vanity.playground.failover_on_datastore_error!
+    assert Vanity.playground.failover_on_datastore_error?
+  end
+
+  def test_default_failover_on_datastore_error
+    proc = Vanity.playground.on_datastore_error
+    assert proc.respond_to?(:call)
+    assert_nothing_raised do
+      proc.call(Exception.new("datastore error"), self.class, caller[0][/`.*'/][1..-2], [1, 2, 3])
+    end
+  end
+
+  def test_request_filter
+    proc = Vanity.playground.request_filter
+    assert proc.respond_to?(:call)
+    assert_nothing_raised do
+      proc.call(dummy_request)
+    end
+  end
+
   def test_chooses_path_sets_default
     assert_equal Vanity.playground.add_participant_path, Vanity::Playground::DEFAULT_ADD_PARTICIPANT_PATH
   end

--- a/test/rails_dashboard_test.rb
+++ b/test/rails_dashboard_test.rb
@@ -53,6 +53,13 @@ class RailsDashboardTest < ActionController::TestCase
     xhr :post, :add_participant, :e => "food", :a => 0
     assert_response :success
     assert @response.body.blank?
+    assert_equal 1, experiment(:food).alternatives.map(&:participants).sum
+  end
+
+  def test_add_participant_with_invalid_request
+    @request.user_agent = "Googlebot/2.1 ( http://www.google.com/bot.html)"
+    xhr :post, :add_participant, :e => "food", :a => 0
+    assert_equal 0, experiment(:food).alternatives.map(&:participants).sum
   end
 
   def test_add_participant_no_params

--- a/test/rails_helper_test.rb
+++ b/test/rails_helper_test.rb
@@ -26,6 +26,11 @@ class RailsHelperTest < ActionView::TestCase
     end
   end
 
+  def test_ab_test_adds_participant_to_experiment
+    ab_test(:pie_or_cake)
+    assert_equal 1, experiment(:pie_or_cake).alternatives.map(&:participants).sum
+  end
+
   def test_vanity_track_url_for_returns_url_with_identity_and_metrics
     self.expects(:url_for).with(:controller => "controller", :action => "action", :_identity => '123', :_track => :sugar_high)
     vanity_track_url_for("123", :sugar_high, :controller => "controller", :action => "action")

--- a/test/rails_test.rb
+++ b/test/rails_test.rb
@@ -47,6 +47,16 @@ class UseVanityControllerTest < ActionController::TestCase
     assert_equal 'false', @response.body
   end
 
+  def test_adds_participant_to_experiment
+    get :index
+    assert_equal 1, experiment(:pie_or_cake).alternatives.map(&:participants).sum
+  end
+
+  def test_does_not_add_invalid_participant_to_experiment
+    @request.user_agent = "Googlebot/2.1 ( http://www.google.com/bot.html)"
+    get :index
+    assert_equal 0, experiment(:pie_or_cake).alternatives.map(&:participants).sum
+  end
 
   def test_vanity_cookie_is_persistent
     get :index


### PR DESCRIPTION
- Closes #175
- Will filter based in JS and non-JS experiments
- Fix default value of Playground#on_datastore_error
