### PR TITLE
Add section on collecting data under development

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -60,6 +60,27 @@ If you're going to store data in the database, run the generator and migrations 
   $ rails generate vanity
   $ rake db:migrate
 
+Experiment data is not collected in the development Rails environment [by default.](http://vanity.labnotes.org/rails.html#config)  To collect the data, you will need to do the following:
+
+1.  Create `config/vanity.yml` and populate it with connection params like the following:
+
+  development:
+    adapter: active_record
+    active_record_adapter: mysql
+    host:     <YOUR_HOST>
+    database: <YOUR_DB>
+    username: <YOUR_USER> 
+    password: <YOUR_PASS>
+    port:     <YOUR_PORT>
+
+1.  Add the following to `config/environments/development.rb`:
+
+  config.after_initialize do
+    Vanity.playground.collecting = true
+  end
+  
+1. Restart your Rails server (if you haven't already)
+
 ==== Step 1.3
 
 Turn Vanity on, and pass a reference to a method that identifies a user. For example:


### PR DESCRIPTION
I lost some time and feel like this was buried too far down in the docs:

```
"There’s generally no need to collect metric and experiment data outside
production environment. Under Rails, Vanity turns collection on only if
the environment name is “production”. You can control this from
config/environments by setting Vanity.playground.collecting to
true/false. When collection is off, Vanity doesn’t connect to the
database server, so there’s no need to set a database configuration for
these environments."
 - http://vanity.labnotes.org/rails.html
```

And wound up having to use these resources to figure out exactly what to do:
    https://groups.google.com/d/msg/vanity-talk/RhqxlqyWN-4/FIbXzeKyooYJ
    https://groups.google.com/forum/#!topic/vanity-talk/opVRJN0KDgk
