### PR TITLE
Adding timestamps to vanity_participants

### DIFF
--- a/generators/templates/vanity_migration.rb
+++ b/generators/templates/vanity_migration.rb
@@ -35,6 +35,7 @@ class VanityMigration < ActiveRecord::Migration
       t.integer :shown
       t.integer :seen
       t.integer :converted
+      t.timestamps
     end
     add_index :vanity_participants, [:experiment_id]
     add_index :vanity_participants, [:experiment_id, :identity], :name => "by_experiment_id_and_identity"

--- a/lib/generators/templates/vanity_migration.rb
+++ b/lib/generators/templates/vanity_migration.rb
@@ -35,6 +35,7 @@ class VanityMigration < ActiveRecord::Migration
       t.integer :shown
       t.integer :seen
       t.integer :converted
+      t.timestamps
     end
     add_index :vanity_participants, [:experiment_id]
     add_index :vanity_participants, [:experiment_id, :identity], :name => "by_experiment_id_and_identity"


### PR DESCRIPTION
Not creating tests because these timestamps are basic ActiveRecord magic.

For those who've already run the vanity generator and resulting
migration and who wish to leverage timestamps, they'll need to add the
following to their migrations:

```
class AddTimestampsToVanityParticipants < ActiveRecord::Migration
  def self.up
    change_table :vanity_participants do |t|
      t.timestamps
    end
  end
  def self.down
    remove_column :vanity_participants, :created_at
    remove_column :vanity_participants, :updated_at
  end
end
```
