### PR TITLE
Use sqlite3 for all active record adapter tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ rvm:
 env:
 - DB=mongodb
 - DB=redis
-- DB=mysql
-#- DB=postgres
+- DB=active_record
 gemfile:
   - Gemfile
   - gemfiles/rails3.gemfile
@@ -22,8 +21,6 @@ gemfile:
 before_script:
 - 'echo ''gem: --no-ri --no-rdoc'' > ~/.gemrc' # skip installing docs for gems
 - if [[ "`basename $BUNDLE_GEMFILE`" == "Gemfile" ]]; then rvm rubygems 1.8.25; fi # Rubygems 2.0.x fails with Rails 2.3
-- if [[ "$DB" == "mysql" ]]; then mysql -e 'create database vanity_test;' >/dev/null; fi
-#- if [[ "$DB" == "pgsql" ]]; then psql -c 'create database vanity_test;' -U postgres >/dev/null; fi
 matrix:
   exclude:
     # Rails 2 is not officially supported on Ruby 1.9.3
@@ -34,7 +31,7 @@ matrix:
       env: DB=redis
       gemfile: Gemfile
     - rvm: 1.9.3
-      env: DB=mysql
+      env: DB=active_record
       gemfile: Gemfile
     # Rails <= 3.2 is not officially supported on Ruby 2.0.0
     - rvm: 2.0.0
@@ -44,7 +41,7 @@ matrix:
       env: DB=redis
       gemfile: Gemfile
     - rvm: 2.0.0
-      env: DB=mysql
+      env: DB=active_record
       gemfile: Gemfile
     - rvm: 2.0.0
       env: DB=mongodb
@@ -53,7 +50,7 @@ matrix:
       env: DB=redis
       gemfile: gemfiles/rails3.gemfile
     - rvm: 2.0.0
-      env: DB=mysql
+      env: DB=active_record
       gemfile: gemfiles/rails3.gemfile
     # Rails >=4 officially supports >= Ruby 1.9.3
     - rvm: 1.8.7
@@ -63,7 +60,7 @@ matrix:
       env: DB=redis
       gemfile: gemfiles/rails4.gemfile
     - rvm: 1.8.7
-      env: DB=mysql
+      env: DB=active_record
       gemfile: gemfiles/rails4.gemfile
   allow_failures:
     - rvm: ruby-head
@@ -74,5 +71,5 @@ matrix:
       env: DB=redis
       gemfile: gemfiles/rails31.gemfile
     - rvm: 2.0.0
-      env: DB=mysql
+      env: DB=active_record
       gemfile: gemfiles/rails31.gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -13,9 +13,7 @@ gem "redis", ">= 2.1"
 gem "redis-namespace", ">= 1.1.0"
 gem "bson_ext"
 gem "mongo"
-gem "mysql"
 gem "sqlite3"
-# gem "pg"
 
 # Math libraries
 gem "backports", :platforms => :mri_18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,6 @@ GEM
       metaclass (~> 0.0.1)
     mongo (1.6.0)
       bson (= 1.6.0)
-    mysql (2.8.1)
     passenger (2.2.15)
       fastthread (>= 1.0.1)
       rack
@@ -102,7 +101,6 @@ DEPENDENCIES
   jekyll
   mocha
   mongo
-  mysql
   passenger (~> 2.0)
   rack
   rails (~> 2.3.8)

--- a/Rakefile
+++ b/Rakefile
@@ -70,7 +70,7 @@ task "test:setup" do
 end
 
 # These are all the adapters we're going to test with.
-ADAPTERS = %w{redis mongodb mysql}
+ADAPTERS = %w{redis mongodb active_record}
 
 desc "Test using different back-ends"
 task "test:adapters", :adapter do |t, args|

--- a/gemfiles/rails3.gemfile
+++ b/gemfiles/rails3.gemfile
@@ -7,7 +7,6 @@ gem "redis", ">= 2.1"
 gem "redis-namespace", ">= 1.1.0"
 gem "bson_ext"
 gem "mongo"
-gem "mysql"
 gem "sqlite3"
 gem "backports", :platforms=>:mri_18
 gem "integration"

--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -90,7 +90,6 @@ GEM
       metaclass (~> 0.0.1)
     mongo (1.6.0)
       bson (= 1.6.0)
-    mysql (2.8.1)
     passenger (3.0.11)
       daemon_controller (>= 0.2.5)
       fastthread (>= 1.0.1)
@@ -157,7 +156,6 @@ DEPENDENCIES
   jekyll
   mocha
   mongo
-  mysql
   passenger (~> 3.0)
   rack
   rails (= 3.0.11)

--- a/gemfiles/rails31.gemfile
+++ b/gemfiles/rails31.gemfile
@@ -7,7 +7,6 @@ gem "redis", ">= 2.1"
 gem "redis-namespace", ">= 1.1.0"
 gem "bson_ext"
 gem "mongo"
-gem "mysql"
 gem "sqlite3"
 gem "backports", :platforms=>:mri_18
 gem "integration"

--- a/gemfiles/rails31.gemfile.lock
+++ b/gemfiles/rails31.gemfile.lock
@@ -90,7 +90,6 @@ GEM
     mongo (1.6.0)
       bson (= 1.6.0)
     multi_json (1.1.0)
-    mysql (2.8.1)
     passenger (3.0.11)
       daemon_controller (>= 0.2.5)
       fastthread (>= 1.0.1)
@@ -166,7 +165,6 @@ DEPENDENCIES
   jekyll
   mocha
   mongo
-  mysql
   passenger (~> 3.0)
   rack
   rails (= 3.1.3)

--- a/gemfiles/rails32.gemfile
+++ b/gemfiles/rails32.gemfile
@@ -7,7 +7,6 @@ gem "redis", ">= 2.1"
 gem "redis-namespace", ">= 1.1.0"
 gem "bson_ext"
 gem "mongo"
-gem "mysql"
 gem "sqlite3"
 gem "backports", :platforms=>:mri_18
 gem "integration"

--- a/gemfiles/rails32.gemfile.lock
+++ b/gemfiles/rails32.gemfile.lock
@@ -91,7 +91,6 @@ GEM
     mongo (1.6.0)
       bson (= 1.6.0)
     multi_json (1.1.0)
-    mysql (2.8.1)
     passenger (3.0.11)
       daemon_controller (>= 0.2.5)
       fastthread (>= 1.0.1)
@@ -166,7 +165,6 @@ DEPENDENCIES
   jekyll
   mocha
   mongo
-  mysql
   passenger (~> 3.0)
   rack
   rails (= 3.2.1)

--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -7,7 +7,6 @@ gem "redis", ">= 2.1"
 gem "redis-namespace", ">= 1.1.0"
 gem "bson_ext"
 gem "mongo"
-gem "mysql"
 gem "sqlite3"
 gem "backports", :platforms=>:mri_18
 gem "integration"

--- a/gemfiles/rails4.gemfile.lock
+++ b/gemfiles/rails4.gemfile.lock
@@ -88,7 +88,6 @@ GEM
     mongo (1.9.2)
       bson (~> 1.9.2)
     multi_json (1.8.2)
-    mysql (2.9.1)
     passenger (3.0.21)
       daemon_controller (>= 1.0.0)
       fastthread (>= 1.0.1)
@@ -164,7 +163,6 @@ DEPENDENCIES
   jekyll
   mocha
   mongo
-  mysql
   passenger (~> 3.0)
   rack
   rails (= 4.0.0)

--- a/test/experiment/ab_test.rb
+++ b/test/experiment/ab_test.rb
@@ -231,12 +231,13 @@ class AbTestTest < ActionController::TestCase
     new_ab_test :foobar do
       alternatives "foo", "bar"
       identify { "6e98ec" }
-      rebalance_frequency 100
+      rebalance_frequency 10
       metrics :coolness
     end
-    assert value = experiment(:foobar).choose.value
+    value = experiment(:foobar).choose.value
+    assert value
     assert_match /foo|bar/, value
-    1000.times do
+    100.times do
       assert_equal value, experiment(:foobar).choose.value
     end
   end

--- a/test/metric/active_record_test.rb
+++ b/test/metric/active_record_test.rb
@@ -264,6 +264,7 @@ context "ActiveRecord Metric" do
       end
     end
     Vanity.playground.metrics
+    Sky.create!
     (1..5).each do |height|
       Sky.create! :height=>height
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -56,8 +56,7 @@ module VanityTestHelpers
   DATABASE = {
     "redis"=>"redis://localhost/15",
     "mongodb"=>"mongodb://localhost/vanity",
-    "mysql"=> { "adapter"=>"active_record", "active_record_adapter"=>"mysql", "database"=>"vanity_test" },
-    "postgres"=> { "adapter"=>"active_record", "active_record_adapter"=>"postgresql", "database"=>"vanity_test", "username"=>"postgres" },
+    "active_record"=> { "adapter"=>"active_record", "active_record_adapter"=>"sqlite3", "database"=>"vanity_test.sqlite3", "timeout" => 10000, "busy_timeout" => 1000 },
     "mock"=>"mock:/"
   }[ENV["DB"]] or raise "No support yet for #{ENV["DB"]}"
 
@@ -88,7 +87,6 @@ module VanityTestHelpers
   # or reload an experiment (saved by the previous playground).
   def new_playground
     Vanity.playground = Vanity::Playground.new(:logger=>$logger, :load_path=>"tmp/experiments")
-    Vanity.playground.establish_connection DATABASE
   end
 
   # Defines the specified metrics (one or more names). Returns metric, or array
@@ -168,14 +166,10 @@ if defined?(ActionController::TestCase)
   end
 end
 
-if ENV["DB"] == "postgres"
-  ActiveRecord::Base.establish_connection :adapter=>"postgresql", :database=>"vanity_test"
-elsif ENV["DB"] == "mysql"
-  ActiveRecord::Base.establish_connection :adapter=>"mysql", :database=>"vanity_test"
-end
-ActiveRecord::Base.logger = $logger
+if ENV["DB"] == "active_record"
+  ActiveRecord::Base.establish_connection :adapter=>"sqlite3", :database=>"vanity_test.sqlite3"
+  ActiveRecord::Base.logger = $logger
 
-if ENV["DB"] == "mysql" || ENV["DB"] == "postgres"
   require "generators/templates/vanity_migration"
   VanityMigration.down rescue nil
   VanityMigration.up


### PR DESCRIPTION
- should increase speed with in-process database
- reduce number of adapters tested (active record is active record is active record, in theory)
- fixes travis killing off threads due to high cpu/memory usage on mysql testing
