### PR TITLE
Refactor first with conditions to where + first

### DIFF
--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -25,6 +25,14 @@ module Vanity
             send :"find_or_create_by_#{method}", value
           end
         end
+
+        def self.rails_agnostic_find_first(conditions)
+          if respond_to? :where
+            where(conditions).first
+          else
+            find(:first, :conditions => conditions)
+          end
+        end
       end
 
       # Schema model
@@ -95,7 +103,7 @@ module Vanity
         # passed then this will be passed to create if creating, or will be
         # used to update the found participant.
         def self.retrieve(experiment, identity, create = true, update_with = nil)
-          if record = VanityParticipant.first(:conditions=>{ :experiment_id=>experiment.to_s, :identity=>identity.to_s })
+          if record = VanityParticipant.rails_agnostic_find_first(:experiment_id=>experiment.to_s, :identity=>identity.to_s)
             record.update_attributes(update_with) if update_with
           elsif create
             record = VanityParticipant.create({ :experiment_id=>experiment.to_s, :identity=>identity.to_s }.merge(update_with || {}))


### PR DESCRIPTION
There's a deprecate use of first with conditions.
First as an alias for `find(:first, *args)` has been deprecated and removed:
- http://apidock.com/rails/ActiveRecord/Base/first/class
- http://apidock.com/rails/ActiveRecord/FinderMethods/first

This caused an exception:

```
UsersMailer#guide_welcome_to_anyroad: processed outbound mail in 79.7ms
ArgumentError: invalid value for Integer(): "{:conditions=>{:experiment_id=>\"guide_welcome_subject\""
from /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:332:in `Integer'
[2] pry(main)> wtf????
Exception: ArgumentError: invalid value for Integer(): "{:conditions=>{:experiment_id=>\"guide_welcome_subject\""
--
 0: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:332:in `Integer'
 1: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:332:in `block in sanitize_limit'
 2: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:332:in `map'
 3: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:332:in `sanitize_limit'
 4: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/relation/query_methods.rb:844:in `build_arel'
 5: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/relation/query_methods.rb:830:in `arel'
 6: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/relation.rb:603:in `exec_queries'
 7: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/relation.rb:487:in `load'
 8: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/relation.rb:231:in `to_a'
 9: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/relation/finder_methods.rb:465:in `find_nth_with_limit'
10: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/relation/finder_methods.rb:130:in `first'
11: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/activerecord-4.1.0/lib/active_record/querying.rb:3:in `first'
12: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/vanity-1.9.1/lib/vanity/adapters/active_record_adapter.rb:98:in `retrieve'
13: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/vanity-1.9.1/lib/vanity/adapters/active_record_adapter.rb:237:in `ab_showing'
14: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/vanity-1.9.1/lib/vanity/experiment/ab_test.rb:140:in `choose'
15: /Users/bogdan/.rvm/gems/ruby-2.1.1@anyroad/gems/vanity-1.9.1/lib/vanity/helpers.rb:44:in `ab_test'
16: /Users/bogdan/workspace/anyroad/ar/app/mailers/users_mailer.rb:23:in `guide_welcome_to_anyroad'
```

The mailer was doing `ab_test(:guide_welcome_subject)`.
This small fix solved it for me.
