### PR TITLE
Fix deprecation warning

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -221,7 +221,7 @@ module Vanity
       def vanity_js
         return if @_vanity_experiments.nil? || @_vanity_experiments.empty?
         javascript_tag do
-          render :file => Vanity.template("_vanity.js.erb")
+          render :file => Vanity.template("_vanity"), :formats => [:js]
         end
       end
 

--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -492,9 +492,7 @@ module Vanity
 
     # Path to template.
     def template(name)
-      path = File.join(File.dirname(__FILE__), "templates/#{name}")
-      path << ".erb" unless name["."]
-      path
+      File.join(File.dirname(__FILE__), "templates/#{name}")
     end
   end
 end


### PR DESCRIPTION
Including handler and format names in render paths (like
'_vanity.js.erb') is deprecated.
