### PR TITLE
Lazy-load Rails frameworks

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -341,7 +341,7 @@ end
 
 
 # Enhance ActionController with use_vanity, filters and helper methods.
-if defined?(ActionController)
+ActiveSupport.on_load(:action_controller) do
   # Include in controller, add view helper methods.
   ActionController::Base.class_eval do
     extend Vanity::Rails::UseVanity
@@ -350,13 +350,12 @@ if defined?(ActionController)
   end
 end
 
-if defined?(ActionMailer)
-  # Include in mailer, add view helper methods.
-  ActionMailer::Base.class_eval do
-    include Vanity::Rails::UseVanityMailer
-    include Vanity::Rails::Filters
-    helper Vanity::Rails::Helpers
-  end
+
+# Include in mailer, add view helper methods.
+ActiveSupport.on_load(:action_mailer) do
+  include Vanity::Rails::UseVanityMailer
+  include Vanity::Rails::Filters
+  helper Vanity::Rails::Helpers
 end
 
 # Reconnect whenever we fork under Passenger.

--- a/test/metric/active_record_test.rb
+++ b/test/metric/active_record_test.rb
@@ -278,6 +278,20 @@ describe "ActiveRecord Metric" do
     end
     assert_in_delta metric(:sky_is_limit).last_update_at.to_i, (Time.now + 1.day).to_i, 1
   end
+
+  it "metric is specifiable with a string" do
+    File.open "tmp/experiments/metrics/sky_is_limit.rb", "w" do |f|
+      f.write <<-RUBY
+        metric "Sky is limit" do
+          model 'Sky'
+        end
+      RUBY
+    end
+    Vanity.playground.metrics
+    Sky.create!
+    assert_equal 1, Vanity::Metric.data(metric(:sky_is_limit)).last.last
+  end
+
 end
 
 end


### PR DESCRIPTION
- Avoid loading ActionController/ActionMailer::Base until they're needed
- Avoid loading ActiveRecord::Base until it's needed

A big part of the reason for the slowness is due to plugins referencing parts of Rails that don't necessarily need to be loaded, so, eg, ActiveRecord::Base gets pulled in even when just trying to run 'rake routes'. As of Rails 3.0, this can be avoided using on_load hooks.
