### PR TITLE
Cherry pick apartmentlist's reset experiment branch

### DIFF
--- a/lib/vanity/adapters/mock_adapter.rb
+++ b/lib/vanity/adapters/mock_adapter.rb
@@ -156,6 +156,10 @@ module Vanity
       def destroy_experiment(experiment)
         @experiments.delete experiment
       end
+
+      def reset_experiment(experiment)
+        @experiments[experiment] = {}
+      end
     end
   end
 end

--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -224,6 +224,11 @@ module Vanity
         end
       end
 
+      def reset_experiment(experiment)
+        @experiments.del "#{experiment}:outcome", "#{experiment}:completed_at"
+        alternatives = @experiments.keys("#{experiment}:alts:*")
+        @experiments.del *alternatives unless alternatives.empty?
+      end
     end
   end
 end

--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -445,6 +445,14 @@ module Vanity
         connection.destroy_experiment @id
         super
       end
+      
+      # clears all collected data for the experiment
+      def reset
+        connection.destroy_experiment @id
+        connection.set_experiment_created_at @id, Time.now
+        @outcome = @completed_at = nil
+        self
+      end
 
       def save
         true_false unless @alternatives

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -317,6 +317,12 @@ module Vanity
         exp.chooses(exp.alternatives[params[:a].to_i].value)
         render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
       end
+      
+      def reset
+        exp = Vanity.playground.experiment(params[:e].to_sym)
+        exp.reset
+        redirect_to url_for(:action=>:index)
+      end
 
       # JS callback action used by vanity_js
       def add_participant

--- a/lib/vanity/templates/_experiment.erb
+++ b/lib/vanity/templates/_experiment.erb
@@ -1,5 +1,7 @@
 <h3><%=vanity_h experiment.name %> <span class="type">(<%= experiment.class.friendly_name %>)</span></h3>
 <%= experiment.description.to_s.split(/\n\s*\n/).map { |para| vanity_html_safe(%{<p class="description">#{vanity_h para}</p>}) }.join.html_safe %>
+<%= button_to "Reset", { :action => "reset", :e => experiment.id },
+  :onclick => "return confirm('Are you sure you want to reset the experiment? This cannot be undone.')", :method => :post %>
 <%= render :file => Vanity.template("_" + experiment.type), :locals => {:experiment => experiment} %>
 <p class="meta">Started <%= experiment.created_at.strftime("%a, %b %d") %>
   <%= " | Completed #{experiment.completed_at.strftime("%a, %b %d")}" unless experiment.active? %></p>

--- a/lib/vanity/templates/vanity.js
+++ b/lib/vanity/templates/vanity.js
@@ -79,4 +79,16 @@ $(function() {
     });
     return false;
   });
+  
+  $(".experiment button.reset").live("click", function() {
+    if (confirm('Are you sure you want to reset the experiment? This will clear all collected data so far and restart the experiment from scratch. This cannot be undone.')){
+      var link = $(this);
+      $.ajax({
+        data: 'authenticity_token=' + encodeURIComponent(document.auth_token),
+        success: function(request){ $('#experiment_' + link.attr("data-id")).html(request) },
+        url: link.attr("data-url"), type: 'post'
+      });
+    }
+    return false;
+  });
 });

--- a/test/experiment/ab_test.rb
+++ b/test/experiment/ab_test.rb
@@ -1021,6 +1021,27 @@ This experiment did not run long enough to find a clear winner.
     assert [:a, :b, :c].include?(choice)
     assert_equal choice, experiment(:simple).choose.value
   end
+  
+  def test_reset_clears_participants
+    new_ab_test :simple do
+      alternatives :a, :b, :c
+      metrics :coolness
+    end
+    experiment(:simple).chooses(:b)
+    assert_equal experiment(:simple).alternatives[1].participants, 1
+    experiment(:simple).reset
+    assert_equal experiment(:simple).alternatives[1].participants, 0
+  end
+  
+  def test_clears_outcome_and_completed_at
+    new_ab_test :simple do
+      alternatives :a, :b, :c
+      metrics :coolness
+    end
+    experiment(:simple).reset
+    assert_nil experiment(:simple).outcome
+    assert_nil experiment(:simple).completed_at
+  end
 
 
   # -- Helper methods --


### PR DESCRIPTION
This implements: clearing outcome & completed_at on reset.

- [ ] needs implementation for other adapters
- [ ] test and verify UI

Cherry-picked and squashed from work done by @cvhoang on https://github.com/jobseekerltd/vanity/commits/master.

Closes #200.