### PR TITLE
remove white-spec: nowrap from dashboard styling

### DIFF
--- a/lib/vanity/templates/vanity.css
+++ b/lib/vanity/templates/vanity.css
@@ -13,7 +13,7 @@
 .vanity .ab_test .choice td { font-weight: bold; background: #f0f0f8 }
 .vanity .ab_test caption { caption-side: bottom; padding: .5em; background: transparent; text-align: left }
 .vanity .ab_test td.option { width: 5em; white-space: nowrap; overflow: hidden }
-.vanity .ab_test td.value { width: 8em; white-space: nowrap; overflow: hidden }
+.vanity .ab_test td.value { width: 8em; overflow: hidden }
 .vanity .ab_test td.action { width: 6em; overflow: hidden; text-align: right }
 
 .vanity .metrics { list-style: none; margin: 0; padding: 0; border-bottom: 1px solid #ddd }


### PR DESCRIPTION
The current way makes it hard to read alternatives that are longer than a few characters long.
