### PR TITLE
fix [ No such file /lib/vanity/templates/_report] when executing vanity ...

### DIFF
--- a/lib/vanity/commands/report.rb
+++ b/lib/vanity/commands/report.rb
@@ -47,7 +47,7 @@ module Vanity
       locals = struct.new(*locals.values_at(*keys))
       dir, base = File.split(path)
       path = File.join(dir, partialize(base))
-      erb = ERB.new(File.read(path), nil, '<>')
+      erb = ERB.new(File.read("#{path}.erb"), nil, '<>')
       erb.filename = path
       erb.result(locals.instance_eval { binding })
     end


### PR DESCRIPTION
Hello Assaf,

There is an issue coming when executing the command **vanity report --output vanity.html**, It is not getting **_report**, because we have erb files and we need to tell full path with extension of file 
**/lib/vanity/templates/_report.erb**.

I have added some fix, If you can merge with your branch, may be helpful to other people :)

Thanks,
