### PR TITLE
Add date to vanity_metric_values index

### DIFF
--- a/lib/generators/templates/vanity_migration.rb
+++ b/lib/generators/templates/vanity_migration.rb
@@ -12,7 +12,7 @@ class VanityMigration < ActiveRecord::Migration
       t.integer :value
       t.string :date
     end
-    add_index :vanity_metric_values, [:vanity_metric_id]
+    add_index :vanity_metric_values, [:vanity_metric_id, :date]
 
     create_table :vanity_experiments do |t|
       t.string :experiment_id


### PR DESCRIPTION
On larger tables this query is a bottleneck. It is most often queries w/ a date range, so we should add that.

I'm not sure if you have a story for a migration path for existing users, but this will at least help new users.
