### PR TITLE
Save experiments only once on load

### DIFF
--- a/test/playground_test.rb
+++ b/test/playground_test.rb
@@ -99,6 +99,19 @@ describe Vanity::Playground do
     end
   end
 
+  describe "#experiments" do
+    it "saves experiments exactly once" do
+      File.open "tmp/experiments/foobar.rb", "w" do |f|
+        f.write <<-RUBY
+          ab_test :foobar do
+          end
+        RUBY
+      end
+      Vanity::Experiment::AbTest.any_instance.expects(:save).once
+      Vanity.playground.experiments
+    end
+  end
+
   describe "participant_info" do
     it "returns participant's experiments" do
       assert_equal [], Vanity.playground.participant_info("abcdef")


### PR DESCRIPTION
This also removed the deprecated Playground#define method as it contributes to the confusion.

This should close #232. Note that the only line that _needed_ to be removed was https://github.com/assaf/vanity/pull/234/files#diff-878670dc9fdffe69dd016dbfedd02ad2L235.

- [ ] Needs to ensure that it still can add multiple hooks in the case of two simultaneous experiments using the same metric.