### PR TITLE
Optimize add_participant action

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -320,12 +320,25 @@ module Vanity
 
       # JS callback action used by vanity_js
       def add_participant
-        if params[:e].nil? || params[:e].empty?
+        if params[:v].nil?
           render :status => 404, :nothing => true
           return
         end
-        exp = Vanity.playground.experiment(params[:e].to_sym)
-        exp.chooses(exp.alternatives[params[:a].to_i].value, request)
+
+        h = {}
+        params[:v].split(',').each do |pair|
+          exp_id, answer = pair.split('=')
+          exp = Vanity.playground.experiment(exp_id.to_s.to_sym) rescue nil
+          answer = answer.to_i
+
+          if !exp || !exp.alternatives[answer]
+            render :status => 404, :nothing => true
+            return
+          end
+          h[exp] = exp.alternatives[answer].value
+        end
+
+        h.each{ |e,a| e.chooses(a, request) }
         render :status => 200, :nothing => true
       end
     end

--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -95,7 +95,7 @@ module Vanity
     # @see Vanity::Experiment
     def experiment(name)
       id = name.to_s.downcase.gsub(/\W/, "_").to_sym
-      warn "Deprecated: pleae call experiment method with experiment identifier (a Ruby symbol)" unless id == name
+      warn "Deprecated: please call experiment method with experiment identifier (a Ruby symbol)" unless id == name
       experiments[id.to_sym] or raise NoExperimentError, "No experiment #{id}"
     end
 

--- a/lib/vanity/templates/_vanity.js.erb
+++ b/lib/vanity/templates/_vanity.js.erb
@@ -1,16 +1,14 @@
 var httpRequest;
-<% @_vanity_experiments.each do |name, alternative| %>
-  var params = "e=<%= name %>&a=<%= alternative.id %>&authenticity_token=<%= CGI.escape(form_authenticity_token) %>";
-  if (window.XMLHttpRequest) { // Mozilla, Safari, ...
-    httpRequest = new XMLHttpRequest();
-  } else if (window.ActiveXObject) { // IE
-    try { httpRequest = new ActiveXObject("Msxml2.XMLHTTP"); }
-    catch (e) { }
-  }
-  if (httpRequest) {
-    httpRequest.open('POST', "<%= Vanity.playground.add_participant_path %>", true);
-    httpRequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-    httpRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
-    httpRequest.send(params);
-  }
-<% end %>
+var params = "v=<%= @_vanity_experiments.map{|name, alternative| "#{name}=#{alternative.id}" }.join(',') %>&authenticity_token=<%= CGI.escape(form_authenticity_token) %>";
+if (window.XMLHttpRequest) { // Mozilla, Safari, ...
+  httpRequest = new XMLHttpRequest();
+} else if (window.ActiveXObject) { // IE
+  try { httpRequest = new ActiveXObject("Msxml2.XMLHTTP"); }
+  catch (e) { }
+}
+if (httpRequest) {
+  httpRequest.open('POST', "<%= Vanity.playground.add_participant_path %>", true);
+  httpRequest.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+  httpRequest.setRequestHeader("X-Requested-With", "XMLHttpRequest");
+  httpRequest.send(params);
+}

--- a/test/frameworks/rails/action_controller_test.rb
+++ b/test/frameworks/rails/action_controller_test.rb
@@ -34,7 +34,7 @@ class UseVanityControllerTest < ActionController::TestCase
   def test_render_js_for_tests
     Vanity.playground.use_js!
     get :js
-    assert_match /script.*e=pie_or_cake.*script/m, @response.body
+    assert_match /script.*v=pie_or_cake=.*script/m, @response.body
   end
 
   def test_chooses_sets_alternatives_for_rails_tests


### PR DESCRIPTION
I'm using JS to track real users (Vanity.playground.use_js!) and skip bots. After I deleted an old experiment, I've started to receive many 500 errors from GoogleBot when it knocked to /vanity/add_participant action for deleted experiment. Also the problem was when I had more than one experiment on a single page - it generates one request for each experiment on each page loading - that is unusual overhead imho. So this PR fixes this problem. Raise 404 (instead of 500) for unknown tests and call add_participants only once for all experiments.
