### PR TITLE
don't suggest using insecure wildcard routes

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -137,7 +137,11 @@ To view metrics and experiment results with the dashboard in Rails 3 & Rails 4:
 
 In <code>config/routes.rb</code>, add:
 
-  match '/vanity(/:action(/:id(.:format)))', :controller => :vanity, :via => [:get, :post]
+  get '/vanity' =>'vanity#index'
+  get '/vanity/participant/:id' => 'vanity#participant'
+  post '/vanity/complete'
+  post '/vanity/chooses'
+  post '/vanity/add_participant'
 
 The controller should look like:
 


### PR DESCRIPTION
the install instructions include adding an insecure wildcard route which opens up an attack vector.

```
match '/vanity(/:action(/:id(.:format)))', :controller => :vanity, :via => [:get, :post]
```

assume that the vanity controller is protected in some way (password, session, etc) - if i can trick an authenticated user into viewing some html i can cause him/her to call `#complete`, `#chooses`, or `#add_participant` via GET with any values i specify:

```
<img src="http://vanity.server/vanity/complete?e=1&a=1&confirmed=1">
```

this will also bypass CSRF protection if the host application has it enabled.

quick fix is to change the docs (ie, this pull request) - better fix is to make vanity into a rails engine and then write these routes in directly yourself.
