### PR TITLE
Introduce Ruby 2.2 support.

### DIFF
--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -302,7 +302,7 @@ module Vanity
 
       # Use the result of #score or #bayes_bandit_score to derive a conclusion. Returns an
       # array of claims.
-      def conclusion(score = score)
+      def conclusion(score = score())
         claims = []
         participants = score.alts.inject(0) { |t,alt| t + alt.participants }
         claims << case participants


### PR DESCRIPTION
Ruby 2.2 introduced a change into how default arguments are parsed[1].

Now when you wish to use a method as a default argument you need to be
explicit by using parenthasis.

For example

`def bar(foo=foo)`

will need to be re-written

`def bar(foo=foo())`

This commit introduces a fix for this issue.

*Note* I initially looked into updating the specs (to use ruby 2.2.0),
however I ran into a number of issues with the appraisal test suite and
older versions of rails.

[1]https://bugs.ruby-lang.org/issues/10314