### PR TITLE
Prevent protected attribute mass-assignment error in ActiveRecordAdapter::VanityRecord

### DIFF
--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -20,7 +20,7 @@ module Vanity
 
         def self.rails_agnostic_find_or_create_by(method, value)
           if respond_to? :find_or_create_by
-            find_or_create_by(method => value)
+            find_or_create_by_without_protection(method => value)
           else
             send :"find_or_create_by_#{method}", value
           end


### PR DESCRIPTION
In Rails 4.1.9, when `track!` is called from a controller, the following error is raised:

ActiveModel::MassAssignmentSecurity::Error (Can't mass-assign protected attributes for Vanity::Adapters::ActiveRecordAdapter::VanityMetric: metric_id)