### PR TITLE
Use existing assignment if available

### DIFF
--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -509,9 +509,10 @@ module Vanity
       # identity, and randomly distributed alternatives for each identity (in the
       # same experiment).
       def alternative_for(identity)
+        existing_assignment = connection.ab_assigned @id, identity
+        return existing_assignment if existing_assignment
+
         if @use_probabilities
-          existing_assignment = connection.ab_assigned @id, identity
-          return existing_assignment if existing_assignment
           random_outcome = rand()
           @use_probabilities.each do |alternative, max_prob|
             return alternative.id if random_outcome < max_prob


### PR DESCRIPTION
previously if probabilities feature was disabled, it would not use the existing assignment

use case: 
if you are doing an experiment and you want to grandfather old users by using `ab_add_participant`

description of problem: 
as of right now `ab_add_participant` won't do anything because when it hits `AbTest#alternative_for`, it just skips down to `Digest::MD5.hexdigest("#{name}/#{identity}").to_i(17) % @alternatives.size` and overwrites the alternative.

anyone willing to help me out with the failing test?