### PR TITLE
Include `db:test:load` in list of blacklisted autoconnect rake tasks.

### DIFF
--- a/lib/vanity/autoconnect.rb
+++ b/lib/vanity/autoconnect.rb
@@ -24,6 +24,7 @@ module Vanity
       'db:seed',
       'db:setup',
       'db:structure:dump',
+      'db:test:load',
       'db:version',
       'doc:app',
       'log:clear',


### PR DESCRIPTION
This is deprecated as of Rails 4.1, but may still be used (especially by rails 3 projects).