### PR TITLE
VanityConversion model "alternative" attr_accessible

### DIFF
--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -79,6 +79,7 @@ module Vanity
       class VanityConversion < VanityRecord
         self.table_name = :vanity_conversions
         belongs_to :vanity_experiment
+        attr_accessible :alternative if needs_attr_accessible?
       end
 
       # Participant model


### PR DESCRIPTION
The "alternative" attribute appears to be mass assigned, so it needs to be attr_accessible.