### PR TITLE
Backport fix for circular argument reference in 2.2.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,8 @@
-== 1.9.0 (2014-04-20)
+== 1.9.3 (2015-10-04)
+
+Cherry-pick fix for ruby 2.2.
+
+== 1.9.1 (2014-04-20)
 
 Include db:reset in blacklist for autoconnect. (@phillbaker)
 Add grace period to Vanity::Metric updated_at (@stangel)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vanity (1.9.2)
+    vanity (1.9.3)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails3.gemfile.lock
+++ b/gemfiles/rails3.gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: ..
   specs:
-    vanity (1.9.2)
+    vanity (1.9.3)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails31.gemfile.lock
+++ b/gemfiles/rails31.gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: ..
   specs:
-    vanity (1.9.2)
+    vanity (1.9.3)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails32.gemfile.lock
+++ b/gemfiles/rails32.gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: ..
   specs:
-    vanity (1.9.2)
+    vanity (1.9.3)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/rails4.gemfile.lock
+++ b/gemfiles/rails4.gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: ..
   specs:
-    vanity (1.9.2)
+    vanity (1.9.3)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -302,7 +302,7 @@ module Vanity
 
       # Use the result of #score or #bayes_bandit_score to derive a conclusion. Returns an
       # array of claims.
-      def conclusion(score = score)
+      def conclusion(score = score())
         claims = []
         participants = score.alts.inject(0) { |t,alt| t + alt.participants }
         claims << case participants

--- a/lib/vanity/version.rb
+++ b/lib/vanity/version.rb
@@ -1,5 +1,5 @@
 module Vanity
-  VERSION = "1.9.2"
+  VERSION = "1.9.3"
 
   module Version
     version = VERSION.to_s.split(".").map { |i| i.to_i }


### PR DESCRIPTION
Cherry-picks 1b5bf18636caa5eae279e2aef2e24c923e63b141.

Closes https://github.com/assaf/vanity/issues/273.