### PR TITLE
proof of concept for dynamic (database) experiments

### DIFF
--- a/lib/generators/templates/vanity_dynamic_experiments_migration.rb
+++ b/lib/generators/templates/vanity_dynamic_experiments_migration.rb
@@ -1,0 +1,30 @@
+class VanityDynamicExperimentsMigration < ActiveRecord::Migration
+  def self.up
+    create_table :vanity_dynamic_experiments do |t|
+      t.string :name
+      t.string :description
+    end
+    add_index :vanity_dynamic_experiments, [:name]
+
+    create_table :vanity_dynamic_experiment_alternatives do |t|
+      t.integer :dynamic_experiment_id
+      t.string :name
+    end
+    add_index :vanity_dynamic_experiment_alternatives, [:name]
+
+
+    create_table :vanity_dynamic_experiment_metrics do |t|
+      t.integer :dynamic_experiment_id
+      t.integer :metric_id
+    end
+    add_index :vanity_dynamic_experiment_metrics, :dynamic_experiment_id
+    add_index :vanity_dynamic_experiment_metrics, :metric_id
+  end
+
+  def self.down
+    drop_table :vanity_dynamic_experiments
+    drop_table :vanity_dynamic_experiment_alternatives
+    drop_table :vanity_dynamic_experiment_metrics
+
+  end
+end

--- a/lib/generators/vanity_dynamic_experiments_generator.rb
+++ b/lib/generators/vanity_dynamic_experiments_generator.rb
@@ -1,0 +1,15 @@
+require 'rails/generators'
+require 'rails/generators/migration'
+
+class VanityDynamicExperimentsGenerator < Rails::Generators::Base
+  include Rails::Generators::Migration
+  source_root File.expand_path('../templates', __FILE__)
+
+  def self.next_migration_number(path)
+    Time.now.utc.strftime("%Y%m%d%H%M%S")
+  end
+
+  def create_model_file
+    migration_template "vanity_dynamic_experiments_migration.rb", "db/migrate/vanity_dynamic_experiments_migration.rb"
+  end
+end

--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -75,6 +75,28 @@ module Vanity
         end
       end
 
+      class VanityDynamicExperiment < VanityRecord
+        self.table_name = :vanity_dynamic_experiments
+
+        has_many :dynamic_experiment_metrics, foreign_key: 'dynamic_experiment_id', class_name: "VanityDynamicExperimentMetric"
+        has_many :metrics, :through => :dynamic_experiment_metrics, class_name: "VanityMetric", foreign_key: 'metric'
+
+        has_many :alternatives, class_name: "VanityDynamicExperimentAlternative", foreign_key: 'dynamic_experiment_id'
+        attr_accessible :metrics, :alternatives if needs_attr_accessible?
+      end
+
+      class VanityDynamicExperimentMetric < VanityRecord
+        self.table_name = :vanity_dynamic_experiment_metrics
+
+        belongs_to :dynamic_experiment, class_name: "VanityDynamicExperiment"
+        belongs_to :metric
+      end
+
+      class VanityDynamicExperimentAlternative < VanityRecord
+        self.table_name = :vanity_dynamic_experiment_alternatives
+        # name
+      end
+
       # Conversion model
       class VanityConversion < VanityRecord
         self.table_name = :vanity_conversions

--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -43,6 +43,10 @@ module Vanity
           self.updated_at = now if updated_before_grace_period?(now)
         end
 
+        def to_label
+          metric_id
+        end
+
         private
 
         def updated_before_grace_period?(now)
@@ -75,27 +79,7 @@ module Vanity
         end
       end
 
-      class VanityDynamicExperiment < VanityRecord
-        self.table_name = :vanity_dynamic_experiments
 
-        has_many :dynamic_experiment_metrics, foreign_key: 'dynamic_experiment_id', class_name: "VanityDynamicExperimentMetric"
-        has_many :metrics, :through => :dynamic_experiment_metrics, class_name: "VanityMetric", foreign_key: 'metric'
-
-        has_many :alternatives, class_name: "VanityDynamicExperimentAlternative", foreign_key: 'dynamic_experiment_id'
-        attr_accessible :metrics, :alternatives if needs_attr_accessible?
-      end
-
-      class VanityDynamicExperimentMetric < VanityRecord
-        self.table_name = :vanity_dynamic_experiment_metrics
-
-        belongs_to :dynamic_experiment, class_name: "VanityDynamicExperiment"
-        belongs_to :metric
-      end
-
-      class VanityDynamicExperimentAlternative < VanityRecord
-        self.table_name = :vanity_dynamic_experiment_alternatives
-        # name
-      end
 
       # Conversion model
       class VanityConversion < VanityRecord

--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -202,7 +202,7 @@ module Vanity
       if experiments[id.to_sym]
         experiments[id.to_sym]
       else
-        dynamic_experiment = Vanity::Adapters::ActiveRecordAdapter::VanityDynamicExperiment.find_by(name: id.to_s)
+        dynamic_experiment = VanityDynamicExperiment.find_by(experiment_name: id.to_s)
         raise NoExperimentError, "No experiment '#{id}'" if !dynamic_experiment
 
         # TODO: this is whack, but I couldn't figure out

--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -202,7 +202,7 @@ module Vanity
       if experiments[id.to_sym]
         experiments[id.to_sym]
       else
-        dynamic_experiment = VanityDynamicExperiment.find_by(experiment_name: id.to_s)
+        dynamic_experiment = VanityDynamicExperiment.find_by(name: id.to_s)
         raise NoExperimentError, "No experiment '#{id}'" if !dynamic_experiment
 
         # TODO: this is whack, but I couldn't figure out


### PR DESCRIPTION
This is provided as a proof-of-concept only. I do not expect you to merge this as-is.

This implementation has a number of drawbacks, and some really whack things about it. It is provided for consideration only.

• Dynamic experiments "live" in their own table (vanity_dynamic_experiments). The intention is that the Editor will edit only that table, and not the vanity_experiments table.

• Because of how Vanity works, it actually ports them over from the vanity_dynamic_experiments into the vanity_experiments table on-the-fly. You can think of vanity_dynamic_experiments as the "setup" for the experiments and vanity_experiments continue to be the actual running experiments. When ported over the string `dynamic_` is appended to the front of the name so that in the vanity_experiments table they can be easily distinguished. As a result, when you refer to the test from `ab_test` (the helper, not the definer), you refer to it using its `dynamic_` prefix. Not sure if I like that but at least it keeps my code-defined experiments nice & separated from the dynamic ones.

• BYOUI: There is no UI. The implementor is expected to bring their own UI for vanity_dynamic_experiments, vanity_dynamic_experiment_alternatives, and vanity_dynamic_experiment_metrics (a join table). The Editor should create experiments & alternatives in the first two, and then create join records in the 3rd. There is no way to create dynamic metrics, since metrics are dependent on serious code implementation this doesn't make sense. All you can do is join your dynamic experiment to the already defined metrics.

(I'm using active_scaffold in my app as a quick & dirty implementation for the UI)

• Of course, you need to implement something in your own app that reads the vanity_dynamic_experiments table at the appropriate time and acts on it. (It makes no sense without it). As well, in my app, I have added additional fields to the vanity_dynamic_experiments and vanity_dynamic_experiment_alternatives tables. Specifically, I have added a `path` field to vanity_dynamic_experiments and a `page_id` to vanity_dynamic_experiment_alternatives. This lets me dynamically choose which page (yup, you guessed it, I have a table of pages) to serve up. Of course, in that logic I have to call `ab_test` first, get the alternative to use based on the user's experiment group, and then re-query back to the vanity_dynamic_experiment_alternatives to get the page_id of the page I want to serve up. It's a little awkward, but it works.

I left these extra fields (my fields) out of the Vanity implementation to facilitate this being decided by the implementer and to not lock-in Vanity to any specific CMS. 

In this code where you implement the switch, I think you actually need to check the table vanity_dynamic_experiments first, then call `Vanity.playground.experiment(x)` to trigger the port. 

_Then_ you can call `ab_test`. I suspect you won't be able to call `ab_test` first.
