### PR TITLE
Merge some ApartmentList changes into Vanity 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ get '/vanity/participant/:id' => 'vanity#participant'
 post '/vanity/complete'
 post '/vanity/chooses'
 post '/vanity/reset'
+post '/vanity/enable'
+post '/vanity/disable'
 post '/vanity/add_participant'
 get '/vanity/image'
 ```

--- a/doc/configuring.textile
+++ b/doc/configuring.textile
@@ -44,9 +44,10 @@ Available configuration options are:
 | request_filter             | A proc that returns whether to to ignore the request for the add JS participant route | Ignore requests with a HTTP_USER_AGENT that contain a URL |
 | templates_path             | Path to templates for Vanity admin | the templates in the gem |
 | use_js                     | Whether to use JS to add particpants, useful to ignore bots | false |
+| experiments_start_enabled  | Whether new experiments start in the enabled or disabled state | true |
 | cookie_name                | The name of the anonymous tracking cookie | @vanity_id@ |
 | cookie_expires             | The duration of the cookie                | 20 years |
-| cookie_domain              | The domain for the cookie. Rails.application.config.session_options[:domain] will be substituted if @nil@.  @nil@ |
+| cookie_domain              | The domain for the cookie. Rails.application.config.session_options[:domain] will be substituted if @nil@. | @nil@ |
 | cookie_path                | The path of the cookie | @nil@ |
 | cookie_secure              | The secure (ssl-only) parameter of the cookie. | @false@ |
 | cookie_httponly            | The httponly parameter of the cookie | @false@ |

--- a/doc/identity.textile
+++ b/doc/identity.textile
@@ -31,6 +31,8 @@ end
 
 If you use either block or method name and they return @nil@, Vanity will fallback on persistent cookie mechanism.
 
+Note that @current_user@ in this case must return @nil@ for non-persisted accounts.  That is, @current_user.id@ *must* be non-@nil@.
+
 An identity can be anything.  For example, if you're running an experiment to test a new feature that will be available in some projects but not others, you'll want to slice the audience by project identifier, not user ID.
 
 You can also give each experiment a different identity using the @identify@ callback.  Here's an example that tells one experiment to use a project identifier:

--- a/lib/generators/templates/vanity_migration.rb
+++ b/lib/generators/templates/vanity_migration.rb
@@ -17,6 +17,7 @@ class VanityMigration < ActiveRecord::Migration
     create_table :vanity_experiments do |t|
       t.string :experiment_id
       t.integer :outcome
+      t.boolean :enabled
       t.datetime :created_at
       t.datetime :completed_at
     end

--- a/lib/vanity/adapters/abstract_adapter.rb
+++ b/lib/vanity/adapters/abstract_adapter.rb
@@ -72,7 +72,7 @@ module Vanity
         fail "Not implemented"
       end
       
-      # Returns true if experiment is enabled, the default (if enabled has not yet been set) is false*
+      # Returns true if experiment is enabled, the default (Vanity.configuration.experiments_start_enabled) is true.
       # (*except for mock_adapter, where default is true for testing)
       def is_experiment_enabled?(experiment)
         fail "Not implemented"

--- a/lib/vanity/adapters/abstract_adapter.rb
+++ b/lib/vanity/adapters/abstract_adapter.rb
@@ -67,6 +67,17 @@ module Vanity
         fail "Not implemented"
       end
 
+      # Store whether an experiment is enabled or not
+      def set_experiment_enabled(experiment, enabled)
+        fail "Not implemented"
+      end
+      
+      # Returns true if experiment is enabled, the default (if enabled has not yet been set) is false*
+      # (*except for mock_adapter, where default is true for testing)
+      def is_experiment_enabled?(experiment)
+        fail "Not implemented"
+      end
+
       # Returns counts for given A/B experiment and alternative (by index).
       # Returns hash with values for the keys :participants, :converted and
       # :conversions.

--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -71,7 +71,7 @@ module Vanity
 
         def increment_conversion(alternative, count = 1)
           record = vanity_conversions.rails_agnostic_find_or_create_by(:alternative, alternative)
-          record.increment!(:conversions, count)
+          record.class.update_counters record.id, conversions: count
         end
       end
 
@@ -200,6 +200,14 @@ module Vanity
       # Returns true if experiment completed.
       def is_experiment_completed?(experiment)
         !!VanityExperiment.retrieve(experiment).completed_at
+      end
+
+      def set_experiment_enabled(experiment, enabled)
+        VanityExperiment.retrieve(experiment).update_attribute(:enabled, enabled)
+      end
+
+      def is_experiment_enabled?(experiment)
+        VanityExperiment.retrieve(experiment).enabled == true
       end
 
       # Returns counts for given A/B experiment and alternative (by index).

--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -207,7 +207,12 @@ module Vanity
       end
 
       def is_experiment_enabled?(experiment)
-        VanityExperiment.retrieve(experiment).enabled == true
+        record = VanityExperiment.retrieve(experiment)
+        if Vanity.configuration.experiments_start_enabled
+          record.enabled != false
+        else
+          record.enabled == true
+        end
       end
 
       # Returns counts for given A/B experiment and alternative (by index).

--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -71,7 +71,7 @@ module Vanity
 
         def increment_conversion(alternative, count = 1)
           record = vanity_conversions.rails_agnostic_find_or_create_by(:alternative, alternative)
-          record.class.update_counters record.id, conversions: count
+          record.class.update_counters(record.id, conversions: count)
         end
       end
 

--- a/lib/vanity/adapters/mock_adapter.rb
+++ b/lib/vanity/adapters/mock_adapter.rb
@@ -102,8 +102,12 @@ module Vanity
       end
 
       def is_experiment_enabled?(experiment)
-        # NOTE: default is true for mock_adapter, but false for all other adapters
-        @experiments[experiment] && (@experiments[experiment][:enabled] == true)
+        record = @experiments[experiment]
+        if Vanity.configuration.experiments_start_enabled
+          record == nil || record[:enabled] != false
+        else
+          record && record[:enabled] == true
+        end
       end
 
       def ab_counts(experiment, alternative)

--- a/lib/vanity/adapters/mock_adapter.rb
+++ b/lib/vanity/adapters/mock_adapter.rb
@@ -95,6 +95,16 @@ module Vanity
       def is_experiment_completed?(experiment)
         @experiments[experiment] && @experiments[experiment][:completed_at]
       end
+      
+      def set_experiment_enabled(experiment, enabled)
+        @experiments[experiment] ||= {}
+        @experiments[experiment][:enabled] = enabled
+      end
+
+      def is_experiment_enabled?(experiment)
+        # NOTE: default is true for mock_adapter, but false for all other adapters
+        @experiments[experiment] && (@experiments[experiment][:enabled] == true)
+      end
 
       def ab_counts(experiment, alternative)
         @experiments[experiment] ||= {}

--- a/lib/vanity/adapters/mongodb_adapter.rb
+++ b/lib/vanity/adapters/mongodb_adapter.rb
@@ -114,6 +114,7 @@ module Vanity
       def get_experiment_created_at(experiment)
         record = @experiments.find_one({ :_id=>experiment }, { :fields=>[:created_at] })
         record && record["created_at"]
+        #Returns nil if either the record or the field doesn't exist
       end
 
       def set_experiment_completed_at(experiment, time)
@@ -127,6 +128,15 @@ module Vanity
 
       def is_experiment_completed?(experiment)
         !!@experiments.find_one(:_id=>experiment, :completed_at=>{ "$exists"=>true })
+      end
+
+      def set_experiment_enabled(experiment, enabled)
+        @experiments.update({ :_id=>experiment }, { "$set"=>{ :enabled=>enabled } }, :upsert=>true)
+      end
+
+      def is_experiment_enabled?(experiment)
+        record = @experiments.find_one({ :_id=>experiment}, { :fields=>[:enabled] })
+        record && (record["enabled"] == true)
       end
 
       def ab_counts(experiment, alternative)

--- a/lib/vanity/adapters/mongodb_adapter.rb
+++ b/lib/vanity/adapters/mongodb_adapter.rb
@@ -136,7 +136,11 @@ module Vanity
 
       def is_experiment_enabled?(experiment)
         record = @experiments.find_one({ :_id=>experiment}, { :fields=>[:enabled] })
-        record && (record["enabled"] == true)
+        if Vanity.configuration.experiments_start_enabled
+          record == nil || record["enabled"] != false
+        else
+          record && record["enabled"] == true
+        end
       end
 
       def ab_counts(experiment, alternative)

--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -134,7 +134,12 @@ module Vanity
       end
 
       def is_experiment_enabled?(experiment)
-        @experiments["#{experiment}:enabled"] == 'true'
+        value = @experiments["#{experiment}:enabled"]
+        if Vanity.configuration.experiments_start_enabled
+          value != 'false'
+        else
+          value == 'true'
+        end
       end
 
       def ab_counts(experiment, alternative)

--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -127,6 +127,16 @@ module Vanity
         end
       end
 
+      def set_experiment_enabled(experiment, enabled)
+        call_redis_with_failover do
+          @experiments.set "#{experiment}:enabled", enabled
+        end
+      end
+
+      def is_experiment_enabled?(experiment)
+        @experiments["#{experiment}:enabled"] == 'true'
+      end
+
       def ab_counts(experiment, alternative)
         {
           :participants => @experiments.scard("#{experiment}:alts:#{alternative}:participants").to_i,

--- a/lib/vanity/configuration.rb
+++ b/lib/vanity/configuration.rb
@@ -51,6 +51,7 @@ module Vanity
       request_filter: ->(request) { default_request_filter(request) },
       templates_path: File.expand_path(File.join(File.dirname(__FILE__), 'templates')),
       use_js: false,
+      experiments_start_enabled: true,
       cookie_name: 'vanity_id',
       cookie_expires: 20 * 365 * 24 * 60 * 60, # 20 years, give or take.
       cookie_domain: nil,
@@ -156,6 +157,9 @@ module Vanity
     attr_writer :config_file
     # In order of precedence, RACK_ENV, RAILS_ENV or `development`.
     attr_writer :environment
+    # By default experiments start enabled. If you want experiments to be
+    # explicitly enabled after a production release, then set to false.
+    attr_writer :experiments_start_enabled
 
     # Cookie name. By default 'vanity_id'
     attr_writer :cookie_name

--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -46,15 +46,13 @@ module Vanity
         @default = value
         @is_default_set = true
         class << self
-          define_method :default, instance_method(:_default)
+          define_method :default do |*args|
+            raise ArgumentError, "default has already been set to #{@default.inspect}" unless args.empty?
+            alternative(@default)
+          end
         end
         nil
       end
-
-      def _default
-        alternative(@default)
-      end
-      private :_default
 
       # -- Enabled --
       

--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -25,6 +25,58 @@ module Vanity
         super
         @score_method = DEFAULT_SCORE_METHOD
         @use_probabilities = nil
+        @is_default_set = false
+      end
+        
+      # -- Default --
+
+      # Call this method once to set a default alternative. Call without 
+      # arguments to obtain the current default.
+      #
+      # @example Set the default alternative
+      #   ab_test "Background color" do
+      #     alternatives "red", "blue", "orange"
+      #     default "red"
+      #   end
+      # @example Get the default alternative
+      #   assert experiment(:background_color).default == "red"
+      # TODO document default choice if not explicitly chosen (first alternative specified)
+      #
+      def default(value)
+        @default = value
+        @is_default_set = true
+        class << self
+          define_method :default, instance_method(:_default)
+        end
+        nil
+      end
+
+      def _default
+        alternative(@default)
+      end
+      private :_default
+
+      # -- Enabled --
+      
+      # Returns true if experiment is enabled, false if disabled.
+      def enabled?
+        !@playground.collecting? || ( active? && connection.is_experiment_enabled?(@id) )
+      end
+      
+      # Enable or disable the experiment. Only works if the playground is collecting
+      # and this experiment is enabled.
+      #
+      # **Note** You should set the enabled/disabled status of an experiment until 
+      # it exists in the database. Ensure that your experiment has had #save invoked
+      # previous to any enabled= calls.
+      def enabled=(bool)
+        return unless @playground.collecting? && active?
+        if created_at.nil?
+          warn 'DB has no created_at for this experiment! This most likely means' + 
+               'you didn\'t call #save before calling enabled=, which you should.'
+        else
+          connection.set_experiment_enabled(@id, bool)
+        end
       end
 
       # -- Metric --
@@ -136,16 +188,23 @@ module Vanity
       def choose(request=nil)
         if @playground.collecting?
           if active?
-            identity = identity()
-            index = connection.ab_showing(@id, identity) || connection.ab_assigned(@id, identity)
-            unless index
-              index = alternative_for(identity).to_i
-              save_assignment_if_valid_visitor(identity, index, request) unless @playground.using_js?
+            if enabled?
+              identity = identity()
+              index = connection.ab_showing(@id, identity) || connection.ab_assigned(@id, identity)
+              unless index
+                index = alternative_for(identity).to_i
+                save_assignment_if_valid_visitor(identity, index, request) unless @playground.using_js?
+              end
+            else
+              # Show the default if experiment is disabled. 
+              index = alternatives.index(default)
             end
           else
+            # If inactive, always show the outcome. Fallback to generation if one can't be found.
             index = connection.ab_get_outcome(@id) || alternative_for(identity)
           end
         else
+          # If collecting=false, show the alternative, but don't track anything.
           identity = identity()
           @showing ||= {}
           @showing[identity] ||= alternative_for(identity)
@@ -419,7 +478,9 @@ module Vanity
       end
 
       def complete!(outcome = nil)
+        # This statement is equivalent to: return unless collecting?
         return unless @playground.collecting? && active?
+        self.enabled = false
         super
 
         unless outcome
@@ -446,6 +507,15 @@ module Vanity
         connection.destroy_experiment @id
         super
       end
+      
+      # clears all collected data for the experiment
+      def reset
+        return unless @playground.collecting?
+        connection.destroy_experiment @id
+        connection.set_experiment_created_at @id, Time.now
+        @outcome = @completed_at = nil
+        self
+      end
 
       # clears all collected data for the experiment
       def reset
@@ -455,9 +525,28 @@ module Vanity
         self
       end
 
+      # Set up tracking for metrics and ensure that the attributes of the ab_test
+      # are valid (e.g. has alternatives, has a default, has metrics).
+      # If collecting, this method will also store this experiment into the db.
+      # In most cases, you call this method right after the experiment's been instantiated
+      # and declared.
       def save
+        if @saved
+          warn "Experiment #{name} has already been saved"
+          return
+        end
+        @saved = true
         true_false unless @alternatives
         fail "Experiment #{name} needs at least two alternatives" unless @alternatives.size >= 2
+        if !@is_default_set
+          default(@alternatives.first)
+          warn "No default alternative specified; choosing #{@default} as default."
+        elsif alternative(@default).nil?
+          #Specified a default that wasn't listed as an alternative; warn and override.
+          warn "Attempted to set unknown alternative #{@default} as default! Using #{@alternatives.first} instead."
+          #Set the instance variable directly since default(value) is no longer defined
+          @default = @alternatives.first
+        end
         super
         if @metrics.nil? || @metrics.empty?
           warn "Please use metrics method to explicitly state which metric you are measuring against."
@@ -471,7 +560,7 @@ module Vanity
 
       # Called via a hook by the associated metric.
       def track!(metric_id, timestamp, count, *args)
-        return unless active?
+        return unless active? && enabled?
         identity = args.last[:identity] if args.last.is_a?(Hash)
         identity ||= identity() rescue nil
         if identity

--- a/lib/vanity/experiment/alternative.rb
+++ b/lib/vanity/experiment/alternative.rb
@@ -88,6 +88,10 @@ module Vanity
           @participants = @converted = @conversions = 0
         end
       end
+
+      def default?
+        @experiment.default == self
+      end
     end
   end
 end

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -330,6 +330,18 @@ module Vanity
         end
       end
 
+      def disable
+        exp = Vanity.playground.experiment(params[:e].to_sym)
+        exp.enabled = false
+        render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
+      end
+      
+      def enable
+        exp = Vanity.playground.experiment(params[:e].to_sym)
+        exp.enabled = true
+        render :file=>Vanity.template("_experiment"), :locals=>{:experiment=>exp}
+      end
+
       def chooses
         exp = Vanity.playground.experiment(params[:e].to_sym)
         exp.chooses(exp.alternatives[params[:a].to_i].value)

--- a/lib/vanity/locales/vanity.en.yml
+++ b/lib/vanity/locales/vanity.en.yml
@@ -1,5 +1,8 @@
 en:
   vanity:
+    act_on_this_experiment:
+      enable: 'Enable this experiment'
+      disable: 'Disable this experiment'
     best_alternative: '(%{probability}% this is best)'
     best_alternative_is_significant: 'With %{probability}% probability this result is statistically significant.'
     best_alternative_probability: 'With %{probability}% probability this result is the best.'
@@ -14,8 +17,14 @@ en:
     converted: '%{count} converted'
     converted_percentage: '%{alternative} converted at %{percentage}%.'
     currently_shown: 'currently shown'
+    default: '(Default)'
     didnt_convert: '%{alternative} did not convert.'
+    disable: 'Disable'
+    disabled: 'Disabled'
+    enable: 'Enable'
+    enabled: 'Enabled'
     experiment_has_been_reset: '%{name} experiment has been reset.'
+    experiment_has_been_disabled: 'This experiment is currently disabled, and will always choose the default %{name}.'
     experiment_participants:
       one: 'There is one participant in this experiment.'
       other: 'There are %{count} participants in this experiment.'

--- a/lib/vanity/locales/vanity.pt-BR.yml
+++ b/lib/vanity/locales/vanity.pt-BR.yml
@@ -17,6 +17,10 @@ pt-BR:
     converted_percentage: '%{alternative} converteu %{percentage}%'
     currently_shown: 'atualmente exibido'
     didnt_convert: '%{alternative} não converteu.'
+    disable: 'Desativar'
+    disabled: 'Desativado'
+    enable: 'Activar'
+    enabled: 'Activado'
     experiment_participants:
       one: 'Há um participante neste experimento.'
       other: 'Há %{count} participantes neste experimento.'

--- a/lib/vanity/templates/_ab_test.erb
+++ b/lib/vanity/templates/_ab_test.erb
@@ -3,14 +3,14 @@
   <caption>
     <%= experiment.conclusion(score).join(" ") %>
     <% if experiment.active? && !experiment.enabled? %>
-      <div class='disabled_info'><%=I18n.t( 'vanity.experiment_has_been_disabled', name: experiment.default.name )%></div>
+      <div class='disabled_info'><%=I18n.t('vanity.experiment_has_been_disabled', name: experiment.default.name)%></div>
     <% end %>
   </caption>
   <% score.alts.each do |alt| %>
     <tr class="<%= "choice" if score.choice == alt %>">
       <td class="option"><%= alt.name.gsub(/^o/, "O") %>:
         <% if alt.default? %>
-          <div class='default'><%=I18n.t( 'vanity.default' )%></div>
+          <div class='default'><%=I18n.t('vanity.default')%></div>
         <% end %>
       </td>
       <td class="value"><code><%=vanity_h alt.value.to_s %></code></td>

--- a/lib/vanity/templates/_ab_test.erb
+++ b/lib/vanity/templates/_ab_test.erb
@@ -2,10 +2,17 @@
 <table>
   <caption>
     <%= experiment.conclusion(score).join(" ") %>
+    <% if experiment.active? && !experiment.enabled? %>
+      <div class='disabled_info'><%=I18n.t( 'vanity.experiment_has_been_disabled', name: experiment.default.name )%></div>
+    <% end %>
   </caption>
   <% score.alts.each do |alt| %>
     <tr class="<%= "choice" if score.choice == alt %>">
-      <td class="option"><%= alt.name.gsub(/^o/, "O") %>:</td>
+      <td class="option"><%= alt.name.gsub(/^o/, "O") %>:
+        <% if alt.default? %>
+          <div class='default'><%=I18n.t( 'vanity.default' )%></div>
+        <% end %>
+      </td>
       <td class="value"><code><%=vanity_h alt.value.to_s %></code></td>
       <td class="value"><%= I18n.t 'vanity.participants', :count=>alt.participants %></td>
       <td class="value"><%= I18n.t 'vanity.converted', :count=>alt.converted %></td>
@@ -14,7 +21,7 @@
         <%= I18n.t('vanity.best_alternative', :probabilty=>alt.probability.to_i) if score.method == :bayes_score %>
         <%= I18n.t('vanity.better_alternative_than', :probability=>alt.difference.to_i, :alternative=>score.least.name) if alt.difference && alt.difference >= 1 %>
       </td>
-      <% if experiment.active? && respond_to?(:url_for) %>
+      <% if experiment.enabled? && experiment.active? && respond_to?(:url_for) %>
         <td class="action">
           <small>
             <% if experiment.showing?(alt) %>

--- a/lib/vanity/templates/_experiment.erb
+++ b/lib/vanity/templates/_experiment.erb
@@ -1,4 +1,24 @@
-<h3><%=vanity_h experiment.name %> <span class="type">(<%= experiment.class.friendly_name %>)</span></h3>
+<% if experiment.active? %>
+  <% status = experiment.enabled? ? 'status_enabled' : 'status_disabled' %>
+<% else %>
+  <% status = 'status_completed' %>
+<% end %>
+<div class="inner <%= status %>">
+<h3>
+  <%=vanity_h experiment.name %><span class="type">(<%= experiment.class.friendly_name %>)</span>
+  <% if experiment.type == 'ab_test' && experiment.active? && experiment.playground.collecting? %>
+    <span class='enabled-links'>
+      <% action = experiment.enabled? ? :disable : :enable %>
+      
+      <% if experiment.enabled? %> <%= I18n.t( 'vanity.enabled' ) %> | <% end %>
+      <a title='<%=I18n.t( action, scope: 'vanity.act_on_this_experiment' )%>' href='#'
+         data-id='<%= experiment.id %>' data-url='<%= url_for(:action=>action, :e => experiment.id) %>'>
+        <%= action %></a>
+      <% if !experiment.enabled? %> | <%= I18n.t( 'vanity.disabled' ) %> <% end %>
+      
+    </span>
+  <% end %>
+</h3>
 <%= experiment.description.to_s.split(/\n\s*\n/).map { |para| vanity_html_safe(%{<p class="description">#{vanity_h para}</p>}) }.join.html_safe %>
 <% if flash.notice %>
   <p>

--- a/lib/vanity/templates/vanity.css
+++ b/lib/vanity/templates/vanity.css
@@ -7,14 +7,22 @@
 .vanity .experiments { list-style: none; margin: 0; padding: 0 }
 .vanity .experiment { margin: 1em 0 2em 0; border-bottom: 1px solid #ddd }
 .vanity .experiment .type { margin-left: .3em; color: #bbb; font-size: .8em; font-weight: normal }
+.vanity .experiment .inner {padding: 1em}
+.vanity .experiment .status_completed { background: #EEF }
+.vanity .experiment .status_enabled { background: #EFE }
+.vanity .experiment .status_disabled { background: #FEE }
+.vanity .experiment .enabled-links { float: right; font-weight: normal }
 
 .vanity .ab_test table { border-collapse: collapse; table-layout: fixed; width: 100%; border-bottom: 1px solid #ccc; margin: 1em 0 0 0 }
 .vanity .ab_test td { padding: .5em; border-top: 1px solid #ccc; width: 2em; overflow: hidden }
 .vanity .ab_test .choice td { font-weight: bold; background: #f0f0f8 }
 .vanity .ab_test caption { caption-side: bottom; padding: .5em; background: transparent; text-align: left }
-.vanity .ab_test td.option { width: 5em; white-space: nowrap; }
-.vanity .ab_test td.value { width: 8em;  }
-.vanity .ab_test td.action { width: 6em; text-align: right }
+.vanity .ab_test caption .disabled_info { padding-top: .5em }
+.vanity .ab_test td.option { width: 5em; white-space: nowrap; overflow: hidden }
+.vanity .ab_test td.option .default { font-size: 75% }
+.vanity .ab_test td.value { width: 8em; white-space: nowrap; overflow: hidden }
+.vanity .ab_test td.action { width: 6em; overflow: hidden; text-align: right }
+.vanity .ab_test button.reset { float: right }
 
 .vanity .metrics { list-style: none; margin: 0; padding: 0; border-bottom: 1px solid #ddd }
 .vanity .metric { margin: 2em 0 }

--- a/lib/vanity/templates/vanity.js
+++ b/lib/vanity/templates/vanity.js
@@ -70,13 +70,42 @@ $(function() {
     });
   });
 
-  $(".experiment.ab_test a.button.chooses").live("click", function() {
-    var link = $(this);
-    $.ajax({
-      data: 'authenticity_token=' + encodeURIComponent(document.auth_token),
-      success: function(request){ $('#experiment_' + link.attr("data-id")).html(request) },
-      url: link.attr("data-url"), type: 'post'
+  function post_on_click(sel) {
+    $(sel).live("click", function() {
+      var link = $(this);
+      $.ajax({
+        data: 'authenticity_token=' + encodeURIComponent(document.auth_token),
+        success: function(request){ $('#experiment_' + link.attr("data-id")).html(request) },
+        url: link.attr("data-url"), type: 'post'
+      });
+      return false;
     });
+  }
+
+  post_on_click(".experiment.ab_test a.button.chooses");
+  post_on_click(".experiment.ab_test .enabled-links a");
+
+  $(".experiment button.reset").live("click", function() {
+    if (confirm('Are you sure you want to reset the experiment? This will clear all collected data so far and restart the experiment from scratch. This cannot be undone.')){
+      var link = $(this);
+      $.ajax({
+        data: 'authenticity_token=' + encodeURIComponent(document.auth_token),
+        success: function(request){ $('#experiment_' + link.attr("data-id")).html(request) },
+        url: link.attr("data-url"), type: 'post'
+      });
+    }
+    return false;
+  });
+  
+  $(".experiment button.finish").live("click", function() {
+    var link = $(this);
+    if (confirm('Are you sure you want to complete the experiment and set ' + link.attr("alt-name") + ' as the outcome?')){
+      $.ajax({
+        data: 'authenticity_token=' + encodeURIComponent(document.auth_token),
+        success: function(request){ $('#experiment_' + link.attr("data-id")).html(request) },
+        url: link.attr("data-url"), type: 'post'
+      });
+    }
     return false;
   });
   

--- a/test/commands/report_test.rb
+++ b/test/commands/report_test.rb
@@ -15,6 +15,7 @@ describe Vanity::Commands do
           alternatives "foo", "bar"
           identify { "me" }
           metrics :coolness
+          default "foo"
         end
         experiment(:foobar).choose
 

--- a/test/frameworks/rails/action_controller_test.rb
+++ b/test/frameworks/rails/action_controller_test.rb
@@ -33,6 +33,8 @@ class UseVanityControllerTest < ActionController::TestCase
     metric :sugar_high
     new_ab_test :pie_or_cake do
       metrics :sugar_high
+      alternatives :pie, :cake
+      default :pie
     end
 
     # Class eval this instead of including in the controller to delay
@@ -64,13 +66,13 @@ class UseVanityControllerTest < ActionController::TestCase
   end
 
   def test_chooses_sets_alternatives_for_rails_tests
-    experiment(:pie_or_cake).chooses(true)
+    experiment(:pie_or_cake).chooses(:pie)
     get :index
-    assert_equal 'true', @response.body
+    assert_equal 'pie', @response.body
 
-    experiment(:pie_or_cake).chooses(false)
+    experiment(:pie_or_cake).chooses(:cake)
     get :index
-    assert_equal 'false', @response.body
+    assert_equal 'cake', @response.body
   end
 
   def test_adds_participant_to_experiment

--- a/test/frameworks/rails/action_mailer_test.rb
+++ b/test/frameworks/rails/action_mailer_test.rb
@@ -28,13 +28,15 @@ class UseVanityMailerTest < ActionMailer::TestCase
     metric :sugar_high
     new_ab_test :pie_or_cake do
       metrics :sugar_high
+      alternatives :pie, :cake
+      default :pie
     end
   end
 
   def test_js_enabled_still_adds_participant
     Vanity.playground.use_js!
     experiment(:pie_or_cake).identify { }
-    experiment(:pie_or_cake).chooses(true)
+    experiment(:pie_or_cake).chooses(:pie)
     VanityMailer.ab_test_subject(nil)
 
 
@@ -45,13 +47,13 @@ class UseVanityMailerTest < ActionMailer::TestCase
   def test_returns_different_alternatives
     experiment(:pie_or_cake).identify { }
 
-    experiment(:pie_or_cake).chooses(true)
+    experiment(:pie_or_cake).chooses(:pie)
     email = VanityMailer.ab_test_subject(nil)
-    assert_equal 'true', email.subject
+    assert_equal 'pie', email.subject
 
-    experiment(:pie_or_cake).chooses(false)
+    experiment(:pie_or_cake).chooses(:cake)
     email = VanityMailer.ab_test_subject(nil)
-    assert_equal 'false', email.subject
+    assert_equal 'cake', email.subject
   end
 
   def test_tracking_image_is_rendered

--- a/test/frameworks/rails/action_view_test.rb
+++ b/test/frameworks/rails/action_view_test.rb
@@ -10,6 +10,7 @@ class RailsHelperTest < ActionView::TestCase
       metrics :sugar_high
       identify { '1' }
       alternatives :pie, :cake
+      default :pie
     end
   end
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -6,6 +6,7 @@ describe Vanity::Helpers do
       metric "Coolness"
       new_ab_test :foobar do
         alternatives "foo", "bar"
+        default "foo"
         metrics :coolness
       end
       Vanity.track!(:coolness, :identity=>'quux')
@@ -17,6 +18,7 @@ describe Vanity::Helpers do
       metric "Coolness"
       new_ab_test :foobar do
         alternatives "foo", "bar"
+        default "foo"
         metrics :coolness
       end
       Vanity.track!(:coolness, :identity=>'quux', :values=>[2])

--- a/test/playground_test.rb
+++ b/test/playground_test.rb
@@ -19,6 +19,7 @@ describe Vanity::Playground do
       f.write <<-RUBY
         ab_test :foobar do
           metrics :coolness
+          default false
         end
       RUBY
     end
@@ -84,6 +85,7 @@ describe Vanity::Playground do
         alternatives "foo", "bar"
         identify { "abcdef" }
         metrics :coolness
+        default "foo"
       end
 
       assert Vanity.playground.experiments_persisted?
@@ -122,6 +124,7 @@ describe Vanity::Playground do
         alternatives "foo", "bar"
         identify { "abcdef" }
         metrics :coolness
+        default "foo"
       end
       alt = experiment(:foobar).choose
       assert_equal [[Vanity.playground.experiment(:foobar), alt]], Vanity.playground.participant_info("abcdef")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -92,7 +92,9 @@ module VanityTestHelpers
   # or reload an experiment (saved by the previous playground).
   def new_playground
     Vanity.playground = Vanity::Playground.new
-    Vanity.playground.establish_connection DATABASE
+    Vanity.disconnect!
+    ActiveRecord::Base.establish_connection
+    Vanity.connect!(DATABASE)
   end
 
 

--- a/test/web/rails/dashboard_test.rb
+++ b/test/web/rails/dashboard_test.rb
@@ -14,12 +14,14 @@ class RailsDashboardTest < ActionController::TestCase
     new_ab_test :food do
       alternatives :apple, :orange
       metrics :sugar_high
+      default :apple
       identify { '1' }
     end
 
     metric :liquidity
     new_ab_test :drink do
       alternatives :tea, :coffee
+      default :tea
       metrics :liquidity
       identify { '1' }
     end


### PR DESCRIPTION
Merged some of the [changes developed by ApartmentList](http://blog.apartmentlist.com/vanity-ab-testing/). ([github](https://github.com/apartmentlist/vanity)).

* Experiments start off in the disabled state, and only become enabled after a dashboard interaction.
* Enable & disable experiments with the push of a button.  When disabled, the `default` choice is used.
* Control when and how experiments should complete by clicking a 'complete' button on the dashboard.
* Changed active record `increment!` to `update_counters` which performs an atomic SQL update.