### PR TITLE
Specify cookie options in configuration.

### DIFF
--- a/doc/configuring.textile
+++ b/doc/configuring.textile
@@ -44,6 +44,7 @@ Available configuration options are:
 | request_filter             | A proc that returns whether to to ignore the request for the add JS participant route | Ignore requests with a HTTP_USER_AGENT that contain a URL |
 | templates_path             | Path to templates for Vanity admin | the templates in the gem |
 | use_js                     | Whether to use JS to add particpants, useful to ignore bots | false |
+| cookie                     | Setting the parameters of the tracking cookie (if used) | @name: vanity_id@ |
 
 When "running under Rails":rails.html, Vanity defaults to using the Rails logger, locates the load_path relative to Rails root, uses the @config/vanity.yml@ configuration file (if present) and turns collection on only in production mode.
 

--- a/doc/configuring.textile
+++ b/doc/configuring.textile
@@ -44,7 +44,12 @@ Available configuration options are:
 | request_filter             | A proc that returns whether to to ignore the request for the add JS participant route | Ignore requests with a HTTP_USER_AGENT that contain a URL |
 | templates_path             | Path to templates for Vanity admin | the templates in the gem |
 | use_js                     | Whether to use JS to add particpants, useful to ignore bots | false |
-| cookie                     | Setting the parameters of the tracking cookie (if used) | @name: vanity_id@ |
+| cookie_name                | The name of the anonymous tracking cookie | @vanity_id@ |
+| cookie_expires             | The duration of the cookie                | 20 years |
+| cookie_domain              | The domain for the cookie. Rails.application.config.session_options[:domain] will be substituted if @nil@.  @nil@ |
+| cookie_path                | The path of the cookie | @nil@ |
+| cookie_secure              | The secure (ssl-only) parameter of the cookie. | @false@ |
+| cookie_httponly            | The httponly parameter of the cookie | @false@ |
 
 When "running under Rails":rails.html, Vanity defaults to using the Rails logger, locates the load_path relative to Rails root, uses the @config/vanity.yml@ configuration file (if present) and turns collection on only in production mode.
 

--- a/lib/vanity/configuration.rb
+++ b/lib/vanity/configuration.rb
@@ -49,7 +49,7 @@ module Vanity
       templates_path: File.expand_path(File.join(File.dirname(__FILE__), 'templates')),
       use_js: false,
       cookie_name: 'vanity_id',
-      cookie_expires: 20.years,
+      cookie_expires: 20 * 365 * 24 * 60 * 60, # 20 years, give or take.
       cookie_domain: nil,
       cookie_path: nil,
       cookie_secure: false,
@@ -156,7 +156,7 @@ module Vanity
     # Cookie name. By default 'vanity_id'
     attr_writer :cookie_name
 
-    # Cookie duration. By default 20.years.
+    # Cookie duration. By default 20 years.
     attr_writer :cookie_expires
 
     # Cookie domain.  By default nil.  If domain is nil then the domain from

--- a/lib/vanity/configuration.rb
+++ b/lib/vanity/configuration.rb
@@ -48,7 +48,12 @@ module Vanity
       request_filter: ->(request) { default_request_filter(request) },
       templates_path: File.expand_path(File.join(File.dirname(__FILE__), 'templates')),
       use_js: false,
-      cookie: { name: 'vanity_id', domain: nil, path: nil, secure: false, httponly: false }
+      cookie_name: 'vanity_id',
+      cookie_expires: 20.years,
+      cookie_domain: nil,
+      cookie_path: nil,
+      cookie_secure: false,
+      cookie_httponly: false,
     }.freeze
 
     # True if saving results to the datastore (participants and conversions).
@@ -148,14 +153,24 @@ module Vanity
     # In order of precedence, RACK_ENV, RAILS_ENV or `development`.
     attr_writer :environment
 
-    # A hash of cookie options, by default:
-    #
-    #   { name: 'vanity_id', expires: 1.month, domain: nil }
-    #
-    # If domain is nil then the domain from
-    # Rails.application.config.session_options[:domain] will be substituted.
-    attr_writer :cookie
+    # Cookie name. By default 'vanity_id'
+    attr_writer :cookie_name
 
+    # Cookie duration. By default 20.years.
+    attr_writer :cookie_expires
+
+    # Cookie domain.  By default nil.  If domain is nil then the domain from
+    # Rails.application.config.session_options[:domain] will be substituted.
+    attr_writer :cookie_domain
+
+    # Cookie path. By default nil.
+    attr_writer :cookie_path
+
+    # Cookie secure. If true, cookie will only be transmitted to SSL pages. By default false.
+    attr_writer :cookie_secure
+
+    # Cookie path. If true, cookie will not be available to JS. By default false.
+    attr_writer :cookie_httponly
 
     # We independently list each attr_accessor to includes docs, otherwise
     # something like DEFAULTS.each { |key, value| attr_accessor key } would be

--- a/lib/vanity/configuration.rb
+++ b/lib/vanity/configuration.rb
@@ -48,6 +48,7 @@ module Vanity
       request_filter: ->(request) { default_request_filter(request) },
       templates_path: File.expand_path(File.join(File.dirname(__FILE__), 'templates')),
       use_js: false,
+      cookie: { name: 'vanity_id', domain: nil, path: nil, secure: false, httponly: false }
     }.freeze
 
     # True if saving results to the datastore (participants and conversions).
@@ -146,6 +147,14 @@ module Vanity
     attr_writer :config_file
     # In order of precedence, RACK_ENV, RAILS_ENV or `development`.
     attr_writer :environment
+
+    # A hash of cookie options, by default:
+    #
+    #   { name: 'vanity_id', expires: 1.month, domain: nil }
+    #
+    # If domain is nil then the domain from
+    # Rails.application.config.session_options[:domain] will be substituted.
+    attr_writer :cookie
 
 
     # We independently list each attr_accessor to includes docs, otherwise

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -56,7 +56,7 @@ module Vanity
             cookie = lambda do |value|
               result = {
                 value: value,
-                expires: Vanity.configuration.cookie_expires.from_now,
+                expires: Time.now + Vanity.configuration.cookie_expires,
                 path: Vanity.configuration.cookie_path,
                 domain: Vanity.configuration.cookie_domain,
                 secure: Vanity.configuration.cookie_secure,

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -54,12 +54,14 @@ module Vanity
             return @vanity_identity if @vanity_identity
 
             cookie = lambda do |value|
-              result = { value: value, 
+              result = {
+                value: value,
                 expires: Vanity.configuration.cookie_expires.from_now,
                 path: Vanity.configuration.cookie_path,
                 domain: Vanity.configuration.cookie_domain,
                 secure: Vanity.configuration.cookie_secure,
-                httponly: Vanity.configuration.cookie_httponly }
+                httponly: Vanity.configuration.cookie_httponly
+              }
               result[:domain] ||= ::Rails.application.config.session_options[:domain]
               result
             end
@@ -71,15 +73,15 @@ module Vanity
             # new user.id to avoid the flash of alternative B (FOAB).
             if request.get? && params[:_identity]
               @vanity_identity = params[:_identity]
-              cookies[ Vanity.configuration.cookie_name ] = cookie.call( @vanity_identity )
+              cookies[Vanity.configuration.cookie_name] = cookie.call(@vanity_identity)
               @vanity_identity
-            elsif cookies[ Vanity.configuration.cookie_name ]
-              @vanity_identity = cookies[ Vanity.configuration.cookie_name ]
+            elsif cookies[Vanity.configuration.cookie_name]
+              @vanity_identity = cookies[Vanity.configuration.cookie_name]
             elsif symbol && object = send(symbol)
               @vanity_identity = object.id
             elsif response # everyday use
-              @vanity_identity = cookies[ Vanity.configuration.cookie_name ] || SecureRandom.hex(16)
-              cookies[ Vanity.configuration.cookie_name ] = cookie.call( @vanity_identity )
+              @vanity_identity = cookies[Vanity.configuration.cookie_name] || SecureRandom.hex(16)
+              cookies[Vanity.configuration.cookie_name] = cookie.call(@vanity_identity)
               @vanity_identity
             else # during functional testing
               @vanity_identity = "test"

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -55,10 +55,11 @@ module Vanity
 
             cookie = lambda do |value|
               result = { value: value, 
-                path: Vanity.configuration.cookie[:path],
-                domain: Vanity.configuration.cookie[:domain],
-                secure: Vanity.configuration.cookie[:secure],
-                httponly: Vanity.configuration.cookie[:httponly] }
+                expires: Vanity.configuration.cookie_expires.from_now,
+                path: Vanity.configuration.cookie_path,
+                domain: Vanity.configuration.cookie_domain,
+                secure: Vanity.configuration.cookie_secure,
+                httponly: Vanity.configuration.cookie_httponly }
               result[:domain] ||= ::Rails.application.config.session_options[:domain]
               result
             end
@@ -70,15 +71,15 @@ module Vanity
             # new user.id to avoid the flash of alternative B (FOAB).
             if request.get? && params[:_identity]
               @vanity_identity = params[:_identity]
-              cookies.permanent[ Vanity.configuration.cookie[:name] ] = cookie.call( @vanity_identity )
+              cookies[ Vanity.configuration.cookie_name ] = cookie.call( @vanity_identity )
               @vanity_identity
-            elsif cookies[ Vanity.configuration.cookie[:name] ]
-              @vanity_identity = cookies[ Vanity.configuration.cookie[:name] ]
+            elsif cookies[ Vanity.configuration.cookie_name ]
+              @vanity_identity = cookies[ Vanity.configuration.cookie_name ]
             elsif symbol && object = send(symbol)
               @vanity_identity = object.id
             elsif response # everyday use
-              @vanity_identity = cookies[ Vanity.configuration.cookie[:name] ] || SecureRandom.hex(16)
-              cookies.permanent[ Vanity.configuration.cookie[:name] ] = cookie.call( @vanity_identity )
+              @vanity_identity = cookies[ Vanity.configuration.cookie_name ] || SecureRandom.hex(16)
+              cookies[ Vanity.configuration.cookie_name ] = cookie.call( @vanity_identity )
               @vanity_identity
             else # during functional testing
               @vanity_identity = "test"

--- a/test/frameworks/rails/action_controller_test.rb
+++ b/test/frameworks/rails/action_controller_test.rb
@@ -91,7 +91,7 @@ class UseVanityControllerTest < ActionController::TestCase
     assert_match /vanity_id=[a-f0-9]{32};/, cookie
     expires = cookie[/expires=(.*)(;|$)/, 1]
     assert expires
-    assert_in_delta Time.parse(expires), Time.now + 1.month, 1.day
+    assert_in_delta Time.parse(expires), Time.now + 20.years, 1.day
   end
 
   def test_vanity_cookie_default_id
@@ -103,6 +103,12 @@ class UseVanityControllerTest < ActionController::TestCase
     @request.cookies["vanity_id"] = "from_last_time"
     get :index
     assert_equal "from_last_time",  cookies["vanity_id"]
+  end
+
+  def test_vanity_cookie_uses_configuration
+    Vanity.configuration.cookie = { name: "new_id" }
+    get :index
+    assert cookies["new_id"] =~ /^[a-f0-9]{32}$/
   end
 
   def test_vanity_identity_set_from_cookie

--- a/test/frameworks/rails/action_controller_test.rb
+++ b/test/frameworks/rails/action_controller_test.rb
@@ -106,7 +106,7 @@ class UseVanityControllerTest < ActionController::TestCase
   end
 
   def test_vanity_cookie_uses_configuration
-    Vanity.configuration.cookie = { name: "new_id" }
+    Vanity.configuration.cookie_name = "new_id"
     get :index
     assert cookies["new_id"] =~ /^[a-f0-9]{32}$/
   end

--- a/test/frameworks/rails/action_controller_test.rb
+++ b/test/frameworks/rails/action_controller_test.rb
@@ -91,7 +91,7 @@ class UseVanityControllerTest < ActionController::TestCase
     assert_match /vanity_id=[a-f0-9]{32};/, cookie
     expires = cookie[/expires=(.*)(;|$)/, 1]
     assert expires
-    assert_in_delta Time.parse(expires), Time.now + 20.years, 1.day
+    assert_in_delta Time.parse(expires), Time.now + 20 * 365 * 24 * 60 * 60, 1.day
   end
 
   def test_vanity_cookie_default_id


### PR DESCRIPTION
* Changed `vanity_id` cookie to a permanent cookie.
* Added ability to change the name, domain, path, secure, and httponly property of the cookie in the Vanity.configuration.