### PR TITLE
Define test alternatives with custom probabilities

### DIFF
--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -47,7 +47,8 @@ module Vanity
 
       # Call this method once to set alternative values for this experiment
       # (requires at least two values). Call without arguments to obtain
-      # current list of alternatives.
+      # current list of alternatives. Call with a hash to set custom
+      # probabilities.
       #
       # @example Define A/B test with three alternatives
       #   ab_test "Background color" do
@@ -55,13 +56,36 @@ module Vanity
       #     alternatives "red", "blue", "orange"
       #   end
       #
+      # @example Define A/B test with custom probabilities
+      #   ab_test "Background color" do
+      #     metrics :coolness
+      #     alternatives "red" => 10, "blue" => 5, "orange => 1
+      #     default "red"
+      #   end
+      #
       # @example Find out which alternatives this test uses
       #   alts = experiment(:background_color).alternatives
       #   puts "#{alts.count} alternatives, with the colors: #{alts.map(&:value).join(", ")}"
       def alternatives(*args)
-        @alternatives ||= args.empty? ? [true, false] : args.clone
-        @alternatives.each_with_index.map do |value, i|
-          Alternative.new(self, i, value)
+        if @alternatives.nil? && args.size == 1 && args[0].instance_of?(Hash)
+          @alternatives = args[0]
+          sum_of_probability = @alternatives.values.reduce(0) { |a,b| a+b }
+          cumulative_probability = 0.0
+          @use_probabilities = []
+          result = []
+          @alternatives = @alternatives.each_with_index.map do |(value, probability), i|
+            result << alternative = Alternative.new( self, i, value )
+            probability = probability.to_f / sum_of_probability
+            @use_probabilities << [ alternative, cumulative_probability += probability ]
+            value
+          end
+
+          result
+        else
+          @alternatives ||= args.empty? ? [true, false] : args.clone
+          @alternatives.each_with_index.map do |value, i|
+            Alternative.new(self, i, value)
+          end
         end
       end
 

--- a/test/experiment/ab_test.rb
+++ b/test/experiment/ab_test.rb
@@ -258,6 +258,17 @@ class AbTestTest < ActionController::TestCase
     end
   end
 
+  def test_uses_configured_probabilities_for_new_assignments
+    new_ab_test :foobar do
+      alternatives "foo" => 30, "bar" => 70
+      identify { rand }
+      metrics :coolness
+    end
+    alts = Array.new(10_000) { experiment(:foobar).choose.value }.reduce({}) { |h,k| h[k] ||= 0; h[k] += 1; h }
+    assert_equal %w{bar foo}, alts.keys.sort
+    assert_in_delta 3000, alts["foo"], 200 # this may fail, such is propability
+  end
+
   def test_uses_probabilities_for_new_assignments
     new_ab_test :foobar do
       alternatives "foo", "bar"

--- a/test/experiment/ab_test.rb
+++ b/test/experiment/ab_test.rb
@@ -260,13 +260,13 @@ class AbTestTest < ActionController::TestCase
 
   def test_uses_configured_probabilities_for_new_assignments
     new_ab_test :foobar do
-      alternatives "foo" => 30, "bar" => 70
+      alternatives "foo" => 30, "bar" => 60
       identify { rand }
       metrics :coolness
     end
     alts = Array.new(10_000) { experiment(:foobar).choose.value }.reduce({}) { |h,k| h[k] ||= 0; h[k] += 1; h }
     assert_equal %w{bar foo}, alts.keys.sort
-    assert_in_delta 3000, alts["foo"], 200 # this may fail, such is propability
+    assert_in_delta 3333, alts["foo"], 200 # this may fail, such is propability
   end
 
   def test_uses_probabilities_for_new_assignments


### PR DESCRIPTION
Allows you to define probabilities for test alternatives using a simple hash format:

```ruby
ab_test "Foo" do
  alternatives :a => 30, :b => 70
end
```