### PR TITLE
ActiveRecord model metrics can provide their own identity source

### DIFF
--- a/doc/metrics.textile
+++ b/doc/metrics.textile
@@ -133,6 +133,16 @@ metric "Signups (Unlimited)" do
 end
 </pre>
 
+The @model@ specifier can also take an @:identity@ option.  @:identity:@ should be a @Proc@ that specifies how to fetch the identity of the experiment participant.  This is useful when constructing objects outside the ActionController context (perhaps in a background task).  However, note that your experiment participants may still be identified by their anonymous cookie identifier, if you started any experiments before the user was identifiable.
+
+This example will record conversions for the Account to which the Subscription belongs:
+
+<pre>
+metric "Subscriptions finished on backend" do
+  description "These signups were actually created in a background task."
+  model Subscription, :identity => lambda { |record| record.account_id }
+end
+</pre>
 
 h3(#ga).  Google Analytics
 

--- a/lib/vanity/metric/active_record.rb
+++ b/lib/vanity/metric/active_record.rb
@@ -49,6 +49,8 @@ module Vanity
         @ar_timestamp, @ar_timestamp_table = @ar_timestamp.to_s.split('.').reverse
         @ar_timestamp_table ||= @ar_scoped.table_name
 
+        @ar_identity_block = options.delete(:identity)
+
         fail "Unrecognized options: #{options.keys * ", "}" unless options.empty?
 
         @ar_scoped.after_create(self)
@@ -99,7 +101,13 @@ module Vanity
       def after_create(record)
         return unless @playground.collecting?
         count = @ar_column ? (record.send(@ar_column) || 0) : 1
-        call_hooks record.send(@ar_timestamp), nil, [count] if count > 0 && @ar_scoped.exists?(record.id)
+
+        identity = Vanity.context.vanity_identity rescue nil
+        identity ||= if @ar_identity_block
+          @ar_identity_block.call( record )
+        end
+        
+        call_hooks record.send(@ar_timestamp), identity, [count] if count > 0 && @ar_scoped.exists?(record.id)
       end
     end
   end

--- a/lib/vanity/metric/active_record.rb
+++ b/lib/vanity/metric/active_record.rb
@@ -104,7 +104,7 @@ module Vanity
 
         identity = Vanity.context.vanity_identity rescue nil
         identity ||= if @ar_identity_block
-          @ar_identity_block.call( record )
+          @ar_identity_block.call(record)
         end
         
         call_hooks record.send(@ar_timestamp), identity, [count] if count > 0 && @ar_scoped.exists?(record.id)

--- a/test/metric/active_record_test.rb
+++ b/test/metric/active_record_test.rb
@@ -270,21 +270,21 @@ describe Vanity::Metric::ActiveRecord do
     end
 
     user = User.create
-    Vanity.context = stub( vanity_identity: user.id )
+    Vanity.context = stub(vanity_identity: user.id)
     experiment = Vanity.playground.experiment(:simple)
     experiment.choose
 
     Vanity.context = nil
-    Sky.create do |sky|
-      sky.user_id = user.id
-    end
-    Sky.create do |sky|
-      sky.user_id = user.id + 1
-    end
+    # Should count as a conversion for the user in the experiment.
+    user.skies.create
 
-    Vanity.context = stub( vanity_identity: "other" )
+    # Should count as a conversion for the newly created User.
+    User.create.skies.create
+
+    Vanity.context = stub(vanity_identity: "other")
     experiment.choose
-    Sky.create( user_id: nil ) 
+    # Should count as a conversion for "other"
+    Sky.create(user_id: nil) 
 
     assert_equal 3, Sky.count
     assert_equal 2, experiment.alternatives.map(&:participants).sum

--- a/test/metric/active_record_test.rb
+++ b/test/metric/active_record_test.rb
@@ -284,7 +284,7 @@ describe Vanity::Metric::ActiveRecord do
     Vanity.context = stub(vanity_identity: "other")
     experiment.choose
     # Should count as a conversion for "other"
-    Sky.create(user_id: nil) 
+    Sky.create
 
     assert_equal 3, Sky.count
     assert_equal 2, experiment.alternatives.map(&:participants).sum


### PR DESCRIPTION
This allows objects created on the backend (outside the ActionController) context to still have an associated identity.

Additionally, fixes a bug with the `after_create` callback so that the current `Vanity.context.vanity_identity` is passed along to properly record the conversion for the participant.