### PR TITLE
Do not build a connection to see if its connected.

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -9,7 +9,7 @@ module Vanity
       # Do this at the very end of initialization, allowing you to change
       # connection adapter, turn collection on/off, etc.
       ::Rails.configuration.after_initialize do
-        Vanity.load! if Vanity.connection.connected?
+        Vanity.load! if Vanity.connected?
       end
     end
 

--- a/lib/vanity/playground.rb
+++ b/lib/vanity/playground.rb
@@ -219,7 +219,7 @@ module Vanity
     # @deprecated
     # @see Vanity.connection
     def connected?
-      Vanity.connection.connected?
+      Vanity.connected?
     end
 
     # @since 1.4.0

--- a/lib/vanity/vanity.rb
+++ b/lib/vanity/vanity.rb
@@ -70,6 +70,10 @@ module Vanity
     end
   end
 
+  def self.connected?
+    @connection && @connection.connected?
+  end
+
   # This is the preferred way to programmatically create a new connection (or
   # switch to a new connection). If no connection was established, the
   # playground will create a new one by calling this method with no arguments.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -63,7 +63,7 @@ module VanityTestHelpers
   def teardown_after
     Vanity.context = nil
     FileUtils.rm_rf "tmp"
-    Vanity.connection.adapter.flushdb if Vanity.connection.connected?
+    Vanity.connection.adapter.flushdb if Vanity.connected?
     WebMock.reset!
   end
 


### PR DESCRIPTION
This avoids trying to require `redis` into Rails when you're using active_record as your data source.