### PR TITLE
When not collecting, always return the default.

### DIFF
--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -197,11 +197,8 @@ module Vanity
             index = connection.ab_get_outcome(@id) || alternative_for(identity)
           end
         else
-          # If collecting=false, show the alternative, but don't track anything.
-          identity = identity()
-          @showing ||= {}
-          @showing[identity] ||= alternative_for(identity)
-          index = @showing[identity]
+          # If collecting=false, show the default, but don't track anything.
+          return default
         end
 
         alternatives[index.to_i]

--- a/test/experiment/ab_test.rb
+++ b/test/experiment/ab_test.rb
@@ -344,21 +344,19 @@ class AbTestTest < ActionController::TestCase
   end
   
   def test_choose_random_when_enabled
-    regardless_of "Vanity.playground.collecting" do
-      metric "Coolness"
+    metric "Coolness"
 
-      exp = new_ab_test :test do 
-        metrics :coolness
-        true_false
-        default false
-        identify { rand }
-      end
-      results = Set.new
-      100.times do
-        results << exp.choose.value
-      end
-      assert_equal results, [true, false].to_set
+    exp = new_ab_test :test do 
+      metrics :coolness
+      true_false
+      default false
+      identify { rand }
     end
+    results = Set.new
+    100.times do
+      results << exp.choose.value
+    end
+    assert_equal results, [true, false].to_set
   end
   
   def test_choose_default_when_disabled
@@ -1336,6 +1334,24 @@ This experiment did not run long enough to find a clear winner.
     end
     experiment(:quick).complete!
     assert_nil experiment(:quick).outcome
+  end
+
+  def test_no_collection_returns_default
+    not_collecting!
+    metric "Coolness"
+
+    exp = new_ab_test :abcd do
+      metrics :coolness
+      alternatives :a, :b, :c, :d
+      default :b
+      identify { rand }
+    end
+
+    results = Set.new
+    100.times do
+      results << exp.choose.value
+    end
+    assert_equal results, [:b].to_set
   end
 
   def test_chooses_records_participants


### PR DESCRIPTION
This changes the behavior of vanity in that when _not_ collecting, we operate as if everything was turned off rather than running experiments but not collecting data.  This gives an easy way to "pause" all running experiments (simply by setting collecting to false and restarting your app).
