### PR TITLE
Preserve connection specification on reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ html
 .rvmrc
 .ruby-version
 .ruby-gemset
+test/dummy/*.sqlite3

--- a/test/vanity_test.rb
+++ b/test/vanity_test.rb
@@ -138,6 +138,16 @@ describe Vanity do
       assert_equal original_specification, Vanity.connection.specification
     end
 
+    it "reconnects with the same configuration if #connect! was called with arguments" do
+      Vanity.connect!(
+        adapter: :mock,
+        url: "redis://1.1.1.1:6379"
+      )
+      original_specification = Vanity.connection.specification
+      Vanity.reconnect!
+      assert_equal original_specification, Vanity.connection.specification
+    end
+
     it "creates a new connection" do
       original_configuration = Vanity.connection
       refute_same original_configuration, Vanity.reconnect!


### PR DESCRIPTION
Hi,

In our app we call `Vanity.connect!` with a connection spec, so that we can use a custom adapter and programmatically determined options, e.g.:

```ruby
Vanity.connect!(
  adapter: :logging_redis_adapter,
  url: OurApp.config.redis_url
)
```

However, when connections are established like this, `Vanity.reconnect!` does not preserve the connection params, and the new connection falls back to the default redis adapter. I've added a failing test to reflect this.

Assuming the intended behaviour is for these values to be preserved, I would be very happy to contribute a fix, but I'd appreciate some feedback on what approach might be best. I notice that currently the `collecting` option is [saved to the configuration](https://github.com/futurelearn/vanity/blob/fde27a90004a0eb24d57d0fdd35630e497a63d48/lib/vanity/vanity.rb#L166-L170) on connection. Could this be expanded to save the full connection params? `Configuration#connection_params` could be modified to be writeable, falling back to params parsed from a file as it [currently does](https://github.com/futurelearn/vanity/blob/fde27a90004a0eb24d57d0fdd35630e497a63d48/lib/vanity/configuration.rb#L207-L227).

What do you think?