### PR TITLE
`Vanity.ab_test` when called from views doesn't work with `use_js = true`

### DIFF
--- a/test/dummy/app/controllers/use_vanity_controller.rb
+++ b/test/dummy/app/controllers/use_vanity_controller.rb
@@ -16,6 +16,20 @@ class UseVanityController < ActionController::Base
     render :inline => "<%= vanity_js -%>"
   end
 
+  def working_js
+    render :inline => <<-EOS
+    <% ab_test(:pie_or_cake) %>
+    <%= vanity_js -%>
+EOS
+  end
+
+  def broken_js
+    render :inline => <<-EOS
+    <% Vanity.ab_test(:pie_or_cake) %>
+    <%= vanity_js -%>
+EOS
+  end
+
   def model_js
     TestModel.new.test_method
     render :inline => "<%= vanity_js -%>"

--- a/test/frameworks/rails/action_controller_test.rb
+++ b/test/frameworks/rails/action_controller_test.rb
@@ -34,6 +34,18 @@ class UseVanityControllerTest < ActionController::TestCase
     assert_match /script.*v=pie_or_cake=.*script/m, @response.body
   end
 
+  def test_working_render_js_for_tests
+    Vanity.playground.use_js!
+    get :working_js
+    assert_match /script.*v=pie_or_cake=.*script/m, @response.body
+  end
+
+  def test_broken_render_js_for_tests
+    Vanity.playground.use_js!
+    get :broken_js
+    assert_match /script.*v=pie_or_cake=.*script/m, @response.body
+  end
+
   def test_render_model_js_for_tests
     Vanity.playground.use_js!
     get :model_js


### PR DESCRIPTION
Hi there,

This PR is not for merge, but includes failing tests to describe an issue we've been having.

## Steps to reproduce:

1. Configure vanity with `use_js = true`
2. Set up an A/B experiment `:pie_or_cake`
3. Use `Vanity.ab_test(:pie_or_cake)` in a view

## Expected behaviour

Visitors to the page hosting the tested view should be added to the experiment via the JS callback

## Actual behaviour

No callback is sent, and visitors are not added

## Issue Description

We've been using Vanity and were confused by the methods `ab_test(:pie_or_cake)` and `Vanity.ab_test(:pie_or_cake)`.  Calling the latter from a view does not lead `vanity_js` to add participants to the experiment. However calling `ab_test(:pie_or_cake)` followed by `vanity_js` in the same view does work. 

The tests included in this PR illustrate the difference in behaviour.

`Vanity.ab_test(:pie_or_cake)` only works when the experiment is initiated in the controller.

I think this can be attributed to the fact that the vanity method `ab_test` exists twice in the codebase of the Vanity gem [1][2]. When calling `ab_test` the method `ab_test` from [1] is invoked and when calling `Vanity.ab_test` the method `ab_test` from [2] is invoked.

The difference between the two seems to lie in how information about the initialization of the Vanity AB test for a participant is shared between the controller and the view. When `Vanity.ab_test`, meaning `ab_test` from [2] is called from the view the information is merely set on the instance of the controller at a time the view has already been rendered.  Subsequently a call to `vanity_js` [3] from the same view does not insert the Javascript snippet into the view needed to add participants to the experiment.

Therefore `Vanity.ab_test` works when being called from the controller prior to rendering of a page that calls `vanity_js`. If the Vanity experiment should be initialized from a view or one of its helpers we should call `ab_test` instead.

* [1] [https://github.com/assaf/vanity/blob/master/lib/vanity/frameworks/rails.rb#L226](https://github.com/assaf/vanity/blob/master/lib/vanity/frameworks/rails.rb#L226)
* [2] [https://github.com/assaf/vanity/blob/master/lib/vanity/helpers.rb#L36](https://github.com/assaf/vanity/blob/master/lib/vanity/helpers.rb#L36)
* [3] [https://github.com/assaf/vanity/blob/master/lib/vanity/frameworks/rails.rb#L253](https://github.com/assaf/vanity/blob/master/lib/vanity/frameworks/rails.rb#L253)

Unfortunately we were not able to find a fix for this issue, but hopefully reproducing this behavior in the test is somewhat useful. 
