### PR TITLE
Implement #ab_seen and #ab_assigned in MockAdapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 vendor
 log/*
-test/dummy/db/*.sqlite3
+test/dummy/**/*.sqlite3
 test/dummy/log/*.log
 test/dummy/tmp/
 

--- a/lib/vanity/adapters/mock_adapter.rb
+++ b/lib/vanity/adapters/mock_adapter.rb
@@ -141,6 +141,20 @@ module Vanity
         alt[:participants] << identity
       end
 
+      def ab_seen(experiment, identity, alternative)
+        if ab_assigned(experiment, identity) == alternative.id
+          alternative
+        end
+      end
+
+      def ab_assigned(experiment, identity)
+        alternatives_for(experiment).each do |alt_id, alt_state|
+          return alt_id if alt_state[:participants].include?(identity)
+        end
+
+        nil
+      end
+
       def ab_add_conversion(experiment, alternative, identity, count = 1, implicit = false)
         @experiments[experiment] ||= {}
         @experiments[experiment][:alternatives] ||= {}
@@ -169,6 +183,15 @@ module Vanity
 
       def destroy_experiment(experiment)
         @experiments.delete experiment
+      end
+
+      private
+
+      def alternatives_for(experiment)
+        @experiments[experiment] ||= {}
+        @experiments[experiment][:alternatives] ||= {}
+
+        @experiments[experiment][:alternatives]
       end
     end
   end

--- a/lib/vanity/adapters/mock_adapter.rb
+++ b/lib/vanity/adapters/mock_adapter.rb
@@ -111,9 +111,7 @@ module Vanity
       end
 
       def ab_counts(experiment, alternative)
-        @experiments[experiment] ||= {}
-        @experiments[experiment][:alternatives] ||= {}
-        alt = @experiments[experiment][:alternatives][alternative] ||= {}
+        alt = alternative(experiment, alternative)
         { :participants => alt[:participants] ? alt[:participants].size : 0,
           :converted    => alt[:converted] ? alt[:converted].size : 0,
           :conversions  => alt[:conversions] || 0 }
@@ -134,9 +132,7 @@ module Vanity
       end
 
       def ab_add_participant(experiment, alternative, identity)
-        @experiments[experiment] ||= {}
-        @experiments[experiment][:alternatives] ||= {}
-        alt = @experiments[experiment][:alternatives][alternative] ||= {}
+        alt = alternative(experiment, alternative)
         alt[:participants] ||= Set.new
         alt[:participants] << identity
       end
@@ -156,9 +152,7 @@ module Vanity
       end
 
       def ab_add_conversion(experiment, alternative, identity, count = 1, implicit = false)
-        @experiments[experiment] ||= {}
-        @experiments[experiment][:alternatives] ||= {}
-        alt = @experiments[experiment][:alternatives][alternative] ||= {}
+        alt = alternative(experiment, alternative)
         alt[:participants] ||= Set.new
         alt[:converted] ||= Set.new
         alt[:conversions] ||= 0
@@ -186,6 +180,11 @@ module Vanity
       end
 
       private
+
+      def alternative(experiment, alternative)
+        alternatives_for(experiment)[alternative] ||= {}
+        alternatives_for(experiment)[alternative]
+      end
 
       def alternatives_for(experiment)
         @experiments[experiment] ||= {}

--- a/test/adapters/mock_adapter_test.rb
+++ b/test/adapters/mock_adapter_test.rb
@@ -191,6 +191,47 @@ describe Vanity::Adapters::MockAdapter do
       end
     end
 
+    describe '#ab_seen' do
+      DummyAlternative = Struct.new(:id)
+
+      before do
+        @alternative_instance = DummyAlternative.new(alternative)
+      end
+
+      it 'returns a truthy value if the identity is assigned to the alternative' do
+        @subject.ab_add_participant(experiment, alternative, identity)
+
+        assert(@subject.ab_seen(experiment, identity, @alternative_instance))
+      end
+
+      it 'returns nil if the identity is not assigned to the alternative' do
+        @subject.ab_add_participant(experiment, alternative, identity)
+
+        assert_equal(
+          nil,
+          @subject.ab_seen(experiment, identity, DummyAlternative.new(2))
+        )
+      end
+    end
+
+    describe '#ab_assigned' do
+      it 'returns the assigned alternative if present' do
+        @subject.ab_add_participant(experiment, alternative, identity)
+
+        assert_equal(
+          alternative,
+          @subject.ab_assigned(experiment, identity)
+        )
+      end
+
+      it 'returns nil if the identity has no assignment' do
+        assert_equal(
+          nil,
+          @subject.ab_assigned(experiment, identity)
+        )
+      end
+    end
+
     describe '#ab_counts' do
       it 'returns the counts of participants, conversions and converted for the alternative' do
         run_experiment

--- a/test/adapters/mock_adapter_test.rb
+++ b/test/adapters/mock_adapter_test.rb
@@ -1,0 +1,246 @@
+require 'test_helper'
+require 'time'
+
+describe Vanity::Adapters::MockAdapter do
+
+  def identity
+    'test-identity'
+  end
+
+  def experiment
+    :experiment
+  end
+
+  def alternative
+    1
+  end
+
+  def metric
+    :purchases
+  end
+
+  def run_experiment
+    @subject.ab_add_participant(experiment, alternative, identity)
+    @subject.ab_add_participant(experiment, alternative, 'other-identity')
+    @subject.ab_add_conversion(experiment, alternative, identity, 2)
+  end
+
+  before do
+    @subject = Vanity::Adapters::MockAdapter.new({})
+    @subject.flushdb
+  end
+
+  describe 'metrics methods' do
+    describe '#get_metric_last_update_at' do
+      it 'is nil if the metric has never been tracked' do
+        refute(@subject.get_metric_last_update_at(metric))
+      end
+
+      it 'returns the time of the last tracked event if present' do
+        time = Time.now
+        @subject.metric_track(metric, time, identity, [1])
+
+        assert_in_delta(
+          time,
+          @subject.get_metric_last_update_at(metric),
+          0.1
+        )
+      end
+    end
+
+    describe '#metric_values' do
+      it 'returns the tracked metrics from the given range, binned by date' do
+        time_1 = Time.iso8601("2016-01-01T00:00:00+00:00")
+        time_2 = Time.iso8601("2016-01-01T12:00:00+00:00")
+        time_3 = Time.iso8601("2016-01-02T00:00:00+00:00")
+        time_4 = Time.iso8601("2016-01-02T12:00:00+00:00")
+        time_5 = Time.iso8601("2016-01-03T12:00:00+00:00")
+
+        @subject.metric_track(metric, time_1, identity, [1, 1])
+        @subject.metric_track(metric, time_2, identity, [2, 1])
+        @subject.metric_track(metric, time_3, identity, [3])
+        @subject.metric_track(metric, time_4, identity, [4, 10])
+        @subject.metric_track(metric, time_5, identity, [5])
+
+        assert_equal(
+          [[3, 2], [7, 10]],
+          @subject.metric_values(metric, time_1, time_4)
+        )
+      end
+    end
+
+    describe '#destroy_metric' do
+      it 'removes all data related to the metric' do
+        @subject.metric_track(metric, Time.now, identity, [1])
+
+        @subject.destroy_metric(metric)
+
+        refute(@subject.get_metric_last_update_at(metric))
+      end
+    end
+  end
+
+  describe 'generic experiment methods' do
+    describe '#experiment_persisted?' do
+      it 'returns false if the experiment is unknown' do
+        refute(@subject.experiment_persisted?(experiment))
+      end
+
+      it 'returns true if the experiment has data' do
+        run_experiment
+
+        assert(@subject.experiment_persisted?(experiment))
+      end
+    end
+
+    describe '#set_experiment_created_at' do
+      it 'sets the experiment creation date' do
+        time = Time.now
+        @subject.set_experiment_created_at(experiment, time)
+
+        assert_equal(time, @subject.get_experiment_created_at(experiment))
+      end
+    end
+
+    describe '#destroy_experiment' do
+      it 'removes all information about the experiment' do
+        run_experiment
+        @subject.destroy_experiment(experiment)
+
+        refute(@subject.experiment_persisted?(experiment))
+      end
+    end
+
+    describe '#is_experiment_enabled?' do
+      def with_experiments_start_enabled(enabled)
+        begin
+          original_value = Vanity.configuration.experiments_start_enabled
+          Vanity.configuration.experiments_start_enabled = enabled
+          yield
+        ensure
+          Vanity.configuration.experiments_start_enabled = original_value
+        end
+      end
+
+      describe 'when experiments start enabled' do
+        it 'is true when the enabled value is unset' do
+          with_experiments_start_enabled(true) do
+            assert(@subject.is_experiment_enabled?(experiment))
+          end
+        end
+
+        it 'is false when the enabled value is set to false' do
+          with_experiments_start_enabled(true) do
+            @subject.set_experiment_enabled(experiment, false)
+
+            refute(@subject.is_experiment_enabled?(experiment))
+          end
+        end
+      end
+
+      describe 'when experiments do not start enabled' do
+        it 'is false when the enabled value is unset' do
+          with_experiments_start_enabled(false) do
+            refute(@subject.is_experiment_enabled?(experiment))
+          end
+        end
+
+        it 'is true when the enabled value is set to true' do
+          with_experiments_start_enabled(false) do
+            @subject.set_experiment_enabled(experiment, true)
+
+            assert(@subject.is_experiment_enabled?(experiment))
+          end
+        end
+      end
+    end
+
+    describe '#is_experiment_completed?' do
+      it 'is true if the completion date is set' do
+        @subject.set_experiment_completed_at(experiment, Time.now)
+
+        assert(@subject.is_experiment_completed?(experiment))
+      end
+
+      it 'is false if the completion date is unset' do
+        refute(@subject.is_experiment_completed?(experiment))
+      end
+    end
+  end
+
+  describe 'A/B test methods' do
+    describe '#ab_add_conversion' do
+      it 'adds the participant and the conversion when implicit=true' do
+        @subject.ab_add_conversion(experiment, alternative, identity, 1, true)
+
+        assert_equal(
+          {:participants => 1, :conversions => 1, :converted => 1},
+          @subject.ab_counts(experiment, alternative)
+        )
+      end
+    end
+
+    describe '#ab_add_participant' do
+      it 'adds the participant to the specified alternative' do
+        @subject.ab_add_participant(experiment, alternative, identity)
+
+        assert_equal(
+          {:participants => 1, :conversions => 0, :converted => 0},
+          @subject.ab_counts(experiment, alternative)
+        )
+      end
+    end
+
+    describe '#ab_counts' do
+      it 'returns the counts of participants, conversions and converted for the alternative' do
+        run_experiment
+
+        assert_equal(
+          {:participants => 2, :conversions => 2, :converted => 1},
+          @subject.ab_counts(experiment, alternative)
+        )
+      end
+    end
+
+    describe '#ab_get_outcome' do
+      it 'returns the outcome if one is set' do
+        @subject.ab_set_outcome(experiment, alternative)
+
+        assert_equal(
+          alternative,
+          @subject.ab_get_outcome(experiment)
+        )
+      end
+
+      it 'returns nil otherwise' do
+        assert_equal(
+          nil,
+          @subject.ab_get_outcome(experiment)
+        )
+      end
+    end
+
+    describe '#ab_show' do
+      it 'forces an alternative to be shown to the given identity' do
+        @subject.ab_show(experiment, identity, alternative)
+
+        assert_equal(
+          alternative,
+          @subject.ab_showing(experiment, identity)
+        )
+      end
+    end
+
+    describe '#ab_not_showing' do
+      it 'cancels a previously-set showing alternative' do
+        @subject.ab_show(experiment, identity, alternative)
+        @subject.ab_not_showing(experiment, identity)
+
+        assert_equal(
+          nil,
+          @subject.ab_showing(experiment, identity)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi there,

While switching to the mock adapter for test usage, we noticed that the `#ab_seen` and `#ab_assigned` methods from the abstract adapter weren't implemented in the mock adapter.

This PR introduces test coverage for the mock adapter, and adds implementations for the missing methods. I'd really appreciate a look-over to make sure I've got the meaning of these methods correct.

At the moment I've only added tests for the metric- and experiment-related methods, not the connection management ones. This because I think the former can probably be extracted and used to test all the adapters, whereas tests for the connection management behaviour are more likely to be adapter-specific. If you're happy to merge this, I'll have a stab at sharing the tests with the redis, mongo etc. adapters.

If there's anything you'd prefer done differently, or something I've missed, just let me know. :)

Cheers,
Simon