### PR TITLE
Change *_filter to *_action to remove dep warning

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -43,11 +43,15 @@ module Vanity
       def use_vanity(method_name = nil, &block)
         define_method(:vanity_identity_block) { block }
         define_method(:vanity_identity_method) { method_name }
-
-        around_action :vanity_context_filter
-        before_action :vanity_reload_filter unless ::Rails.configuration.cache_classes
-        before_action :vanity_query_parameter_filter
-        after_action :vanity_track_filter
+        unless responds_to?(:before_action)
+          alias_method :before_action, :before_filter
+          alias_method :around_action, :around_filter
+          alias_method :after_action, :after_filter
+        end
+          around_action :vanity_context_filter
+          before_action :vanity_reload_filter unless ::Rails.configuration.cache_classes
+          before_action :vanity_query_parameter_filter
+          after_action :vanity_track_filter 
       end
       protected :use_vanity
     end

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -44,10 +44,10 @@ module Vanity
         define_method(:vanity_identity_block) { block }
         define_method(:vanity_identity_method) { method_name }
 
-        around_filter :vanity_context_filter
-        before_filter :vanity_reload_filter unless ::Rails.configuration.cache_classes
-        before_filter :vanity_query_parameter_filter
-        after_filter :vanity_track_filter
+        around_action :vanity_context_filter
+        before_action :vanity_reload_filter unless ::Rails.configuration.cache_classes
+        before_action :vanity_query_parameter_filter
+        after_action :vanity_track_filter
       end
       protected :use_vanity
     end

--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -43,7 +43,7 @@ module Vanity
       def use_vanity(method_name = nil, &block)
         define_method(:vanity_identity_block) { block }
         define_method(:vanity_identity_method) { method_name }
-        unless responds_to?(:before_action)
+        unless respond_to?(:before_action)
           alias_method :before_action, :before_filter
           alias_method :around_action, :around_filter
           alias_method :after_action, :after_filter


### PR DESCRIPTION
This change renames the `before_filter` and `after_filter` calls to be Rails 5 compatible to remove deprecation warnings.

Resolves Issue #314