### PR TITLE
Deprecate calling #ab_seen with alternative instance

### DIFF
--- a/lib/vanity/adapters/abstract_adapter.rb
+++ b/lib/vanity/adapters/abstract_adapter.rb
@@ -142,6 +142,16 @@ module Vanity
         fail "Not implemented"
       end
 
+      private
+
+      def with_ab_seen_deprecation(experiment, identity, alternative)
+        if alternative.respond_to?(:id)
+          Vanity.configuration.logger.warn(%q{Deprecated: #ab_seen should be passed the alternative id, not an Alternative instance})
+          yield experiment, identity, alternative.id
+        else
+          yield experiment, identity, alternative
+        end
+      end
     end
   end
 end

--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -255,9 +255,11 @@ module Vanity
       end
 
       # Determines if a participant already has seen this alternative in this experiment.
-      def ab_seen(experiment, identity, alternative)
-        participant = VanityParticipant.retrieve(experiment, identity, false)
-        participant && participant.seen == alternative.id
+      def ab_seen(experiment, identity, alternative_or_id)
+        with_ab_seen_deprecation(experiment, identity, alternative_or_id) do |expt, ident, alt_id|
+          participant = VanityParticipant.retrieve(expt, ident, false)
+          participant && participant.seen == alt_id
+        end
       end
 
       # Returns the participant's seen alternative in this experiment, if it exists

--- a/lib/vanity/adapters/mock_adapter.rb
+++ b/lib/vanity/adapters/mock_adapter.rb
@@ -137,9 +137,11 @@ module Vanity
         alt[:participants] << identity
       end
 
-      def ab_seen(experiment, identity, alternative)
-        if ab_assigned(experiment, identity) == alternative.id
-          alternative
+      def ab_seen(experiment, identity, alternative_or_id)
+        with_ab_seen_deprecation(experiment, identity, alternative_or_id) do |expt, ident, alt_id|
+          if ab_assigned(expt, ident) == alt_id
+            alt_id
+          end
         end
       end
 

--- a/lib/vanity/adapters/mongodb_adapter.rb
+++ b/lib/vanity/adapters/mongodb_adapter.rb
@@ -200,9 +200,11 @@ module Vanity
       end
 
       # Determines if a participant already has seen this alternative in this experiment.
-      def ab_seen(experiment, identity, alternative)
-        participant = @participants.find(:experiment=>experiment, :identity=>identity).limit(1).projection(:seen=>1).first
-        participant && participant["seen"].first == alternative.id
+      def ab_seen(experiment, identity, alternative_or_id)
+        with_ab_seen_deprecation(experiment, identity, alternative_or_id) do |expt, ident, alt_id|
+          participant = @participants.find(:experiment=>expt, :identity=>ident).limit(1).projection(:seen=>1).first
+          participant && participant["seen"].first == alt_id
+        end
       end
 
       # Returns the participant's seen alternative in this experiment, if it exists

--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -175,12 +175,14 @@ module Vanity
         end
       end
 
-      def ab_seen(experiment, identity, alternative)
-        call_redis_with_failover(experiment, identity, alternative) do
-          if @experiments.sismember "#{experiment}:alts:#{alternative.id}:participants", identity
-            alternative
-          else
-            nil
+      def ab_seen(experiment, identity, alternative_or_id)
+        with_ab_seen_deprecation(experiment, identity, alternative_or_id) do |expt, ident, alt_id|
+          call_redis_with_failover(expt, ident, alt_id) do
+            if @experiments.sismember "#{expt}:alts:#{alt_id}:participants", ident
+              alt_id
+            else
+              nil
+            end
           end
         end
       end

--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -635,7 +635,7 @@ module Vanity
         # if we have an on_assignment block, call it on new assignments
         if defined?(@on_assignment_block) && @on_assignment_block
           assignment = alternatives[index]
-          if !connection.ab_seen @id, identity, assignment
+          if !connection.ab_seen @id, identity, index
             @on_assignment_block.call(Vanity.context, identity, assignment, self)
           end
         end

--- a/test/vanity_test.rb
+++ b/test/vanity_test.rb
@@ -108,12 +108,16 @@ describe Vanity do
           f.write(connection_config)
         end
 
-        Vanity.reset!
-        Vanity.disconnect!
-        Vanity::Connection.stubs(:new)
-        Vanity.connect!
+        out, _err = capture_io do
+          Vanity.reset!
+          Vanity.configuration.logger = Logger.new($stdout)
+          Vanity.disconnect!
+          Vanity::Connection.stubs(:new)
+          Vanity.connect!
+        end
 
         assert_equal false, Vanity.configuration.collecting
+        assert_match(/Deprecated/, out)
       end
     end
   end


### PR DESCRIPTION
As noted in #309, the `#ab_seen` adapter method currently takes an instance of `Alternative`, where all other adapter methods take an alternative id.

Since this has the potential to cause confusion, I thought it might be best to support both calling styles, logging a deprecation notice if the method is called with an `Alternative` instance, but still returning the correct response. We can then remove support for the old method signature after a respectful period of silence. :-)

(I've also silenced the deprecation warnings emitted by another test, hope that's okay.)