### PR TITLE
Show more data in the metrics view

### DIFF
--- a/lib/vanity/templates/_metric.erb
+++ b/lib/vanity/templates/_metric.erb
@@ -1,14 +1,18 @@
 <h3><%=vanity_h metric.name %></h3>
 <%= vanity_simple_format(vanity_h(metric.description), :class=>"description") %>
+<%- metric_data = Vanity::Metric.data(metric) %>
 <%= vanity_html_safe(%Q{<div class="chart"></div>
     <script type="text/javascript">
     $(function() {
       Vanity.metric("#{vanity_h(id)}")
         .plot([{
           label:"#{vanity_h(metric.name)}",
-          data: [#{Vanity::Metric.data(metric).map { |date,value| "['#{date.to_time.httpdate}',#{value}]" }.join(",")}]
+          data: [#{metric_data.map { |date,value| "['#{date.to_time.httpdate}',#{value}]" }.join(",")}]
         }])
     })
     </script>}
-  )
+    )
 %>
+<%- sum = 0 %>
+<%- metric_data.each{|data|sum += data[1]} %>
+<%= "#{I18n.t('vanity.templates.metric.sum')}: #{sum}" %>

--- a/lib/vanity/templates/vanity.js
+++ b/lib/vanity/templates/vanity.js
@@ -18,6 +18,16 @@ Vanity.tooltip = function(event, pos, item) {
   }
 }
 
+
+function ticksArray(axis) {
+    var array = [0];
+    if(axis.max > 1) {
+        array.push(axis.max / 2);
+    }
+    array.push(axis.max);
+    return array;
+}
+
 Vanity.metric = function(id) {      
   var metric = {};
   metric.chart = $("#metric_" + id + " .chart");
@@ -25,7 +35,7 @@ Vanity.metric = function(id) {
   metric.markings = [];
   metric.options = {
     xaxis:  { mode: "time", minTickSize: [7, "day"] },
-    yaxis:  { ticks: [0, 100], autoscaleMargin: null },
+    yaxis:  { ticks: ticksArray, autoscaleMargin: null },
     series: { lines: { show: true, lineWidth: 2, fill: true, fillColor: { colors: ["#fff", "#C6D2DA"] } },
               points: { show: false, radius: 1 }, shadowSize: 0 },
     colors: ["#0077CC"],

--- a/lib/vanity/templates/vanity.js
+++ b/lib/vanity/templates/vanity.js
@@ -28,6 +28,10 @@ function ticksArray(axis) {
     return array;
 }
 
+function tickFormatter(value, axis) {
+    return value.toFixed(0);
+}
+
 Vanity.metric = function(id) {      
   var metric = {};
   metric.chart = $("#metric_" + id + " .chart");
@@ -35,7 +39,7 @@ Vanity.metric = function(id) {
   metric.markings = [];
   metric.options = {
     xaxis:  { mode: "time", minTickSize: [7, "day"] },
-    yaxis:  { ticks: ticksArray, autoscaleMargin: null },
+    yaxis:  { ticks: ticksArray, tickFormatter: tickFormatter, autoscaleMargin: null },
     series: { lines: { show: true, lineWidth: 2, fill: true, fillColor: { colors: ["#fff", "#C6D2DA"] } },
               points: { show: false, radius: 1 }, shadowSize: 0 },
     colors: ["#0077CC"],


### PR DESCRIPTION
I have made some changes (especially for our needs) to show more data in the metric-view. It is not configureable to determine how the metric-graphs will be build. It would be comfortable to configure vanity (or a changed behaviour of vanity using flot), so we can see more data in the views. Without this data included, the graphs are at the moment useless for us.