### PR TITLE
Use send to change _filter/_action callbacks for Rails 5

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -44,10 +44,11 @@ module Vanity
         define_method(:vanity_identity_block) { block }
         define_method(:vanity_identity_method) { method_name }
 
-        around_filter :vanity_context_filter
-        before_filter :vanity_reload_filter unless ::Rails.configuration.cache_classes
-        before_filter :vanity_query_parameter_filter
-        after_filter :vanity_track_filter
+        callback_method_name = respond_to?(:before_action) ? :action : :filter
+        send(:"around_#{callback_method_name}", :vanity_context_filter)
+        send(:"before_#{callback_method_name}", :vanity_reload_filter) unless ::Rails.configuration.cache_classes
+        send(:"before_#{callback_method_name}", :vanity_query_parameter_filter)
+        send(:"after_#{callback_method_name}", :vanity_track_filter)
       end
       protected :use_vanity
     end


### PR DESCRIPTION
This change renames the before_filter and after_filter calls to be Rails 5 compatible. It is based on the feedback in PR #315.

I've been running this patch in production and it's working well.

Sorry to open a duplicative PR, but I didn't hear back from @terracatta when I opened a PR against their PR: https://github.com/terracatta/vanity/pull/1

Thank you for this awesome gem.