### PR TITLE
Do not use delete_all's deprecated parameters (Rails 5.1 compatibility)

### DIFF
--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -292,7 +292,7 @@ module Vanity
 
       # Deletes all information about this experiment.
       def destroy_experiment(experiment)
-        VanityParticipant.delete_all(:experiment_id => experiment.to_s)
+        VanityParticipant.where(:experiment_id => experiment.to_s).delete_all
         record = VanityExperiment.find_by_experiment_id(experiment.to_s)
         record && record.destroy
       end


### PR DESCRIPTION
This replaces `delete_all(conditions)` with `where(conditions).delete_all`. 

This is necessary for Rails 5.1 as `delete_all` [no longer receives conditions](https://github.com/rails/rails/pull/27503/commits/e7381d289e4f8751dcec9553dcb4d32153bd922b).