### PR TITLE
Fix `add_participant` on Rails 5.1

### DIFF
--- a/lib/vanity/frameworks/rails.rb
+++ b/lib/vanity/frameworks/rails.rb
@@ -316,7 +316,7 @@ module Vanity
       # JS callback action used by vanity_js
       def add_participant
         if params[:v].nil?
-          render :status => 404, :nothing => true
+          head 404
           return
         end
 
@@ -327,14 +327,14 @@ module Vanity
           answer = answer.to_i
 
           if !exp || !exp.alternatives[answer]
-            render :status => 404, :nothing => true
+            head 404
             return
           end
           h[exp] = exp.alternatives[answer].value
         end
 
         h.each{ |e,a| e.chooses(a, request) }
-        render :status => 200, :nothing => true
+        head 200
       end
     end
 


### PR DESCRIPTION
In Rails 5 the `render` method deprecated a number of options including
the `nothing` option [1] (this option was removed entirely in Rails
5.1).

Previously vanity relied on this method for implementing its
`add_participant` controller endpoint.

Rather than using `render nothing: true`, we can use the `head` method
if we do not require a body in the response.

**Notes**

It looks like the `head` method is available in all versions of Rails
supported by Vanity (including Rails 3.2).

[1] https://github.com/rails/rails/pull/20336