### PR TITLE
Race condition when creating experiments using AR adapter

### DIFF
--- a/lib/generators/templates/add_unique_indexes_migration.rb
+++ b/lib/generators/templates/add_unique_indexes_migration.rb
@@ -1,0 +1,28 @@
+require "vanity/adapters/active_record_adapter"
+
+class AddVanityUniqueIndexes < ActiveRecord::Migration
+  # Helper methods to ensure we're connecting to the right database, see
+  # https://github.com/assaf/vanity/issues/295.
+
+  def connection
+    @connection ||= ActiveRecord::Base.connection
+  end
+  alias_method :default_connection, :connection
+
+  def with_vanity_connection
+    @connection = Vanity::Adapters::ActiveRecordAdapter::VanityRecord.connection
+    yield
+    @connection = default_connection
+  end
+
+  def change
+    with_vanity_connection do
+      remove_index :vanity_experiments, [:experiment_id]
+      add_index :vanity_experiments, [:experiment_id], :unique => true
+
+      remove_index :vanity_conversions, :name => "by_experiment_id_and_alternative", :unique => true
+      add_index :vanity_conversions, [:vanity_experiment_id, :alternative], :name => "by_experiment_id_and_alternative", :unique => true
+    end
+  end
+
+end

--- a/lib/generators/templates/vanity_migration.rb
+++ b/lib/generators/templates/vanity_migration.rb
@@ -38,14 +38,14 @@ class VanityMigration < ActiveRecord::Migration
         t.datetime :created_at
         t.datetime :completed_at
       end
-      add_index :vanity_experiments, [:experiment_id]
+      add_index :vanity_experiments, [:experiment_id], :unique => true
 
       create_table :vanity_conversions do |t|
         t.integer :vanity_experiment_id
         t.integer :alternative
         t.integer :conversions
       end
-      add_index :vanity_conversions, [:vanity_experiment_id, :alternative], :name => "by_experiment_id_and_alternative"
+      add_index :vanity_conversions, [:vanity_experiment_id, :alternative], :name => "by_experiment_id_and_alternative", :unique => true
 
       create_table :vanity_participants do |t|
         t.string :experiment_id

--- a/lib/generators/vanity/add_unique_indexes_generator.rb
+++ b/lib/generators/vanity/add_unique_indexes_generator.rb
@@ -1,0 +1,15 @@
+require 'rails/generators'
+require 'rails/generators/migration'
+
+class Vanity::AddUniqueIndexesGenerator < Rails::Generators::Base
+  include Rails::Generators::Migration
+  source_root File.expand_path('../../templates', __FILE__)
+
+  def self.next_migration_number(path)
+    Time.now.utc.strftime("%Y%m%d%H%M%S")
+  end
+
+  def create_model_file
+    migration_template "add_unique_indexes_migration.rb", "db/migrate/add_vanity_unique_indexes.rb"
+  end
+end

--- a/lib/vanity/adapters/active_record_adapter.rb
+++ b/lib/vanity/adapters/active_record_adapter.rb
@@ -19,10 +19,20 @@ module Vanity
         end
 
         def self.rails_agnostic_find_or_create_by(method, value)
-          if respond_to? :find_or_create_by
-            find_or_create_by(method => value)
-          else
-            send :"find_or_create_by_#{method}", value
+          retried = false
+          begin
+            if respond_to? :find_or_create_by
+              find_or_create_by(method => value)
+            else
+              send :"find_or_create_by_#{method}", value
+            end
+          rescue ActiveRecord::RecordNotUnique
+            if retried
+              raise
+            else
+              retried = true
+              retry
+            end
           end
         end
       end


### PR DESCRIPTION
I've noticed that there's a race condition using the activerecord adapater when vanity creates experiments or rows in the conversions table - ever now and a again we end up with duplicate rows in those tables.

This can be fixed by adding unique indexes to those tables and with the code change in this PR. The default vanity migrations should also be changed for this to be effective, but I'm not sure how that is usually managed (for example, how do existing users update their vanity tables?)

