### PR TITLE
Prevent dupe participation in same experiment

### DIFF
--- a/lib/generators/templates/add_participants_unique_index_migration.rb
+++ b/lib/generators/templates/add_participants_unique_index_migration.rb
@@ -1,6 +1,6 @@
 require "vanity/adapters/active_record_adapter"
 
-class AddVanityUniqueIndexes < ActiveRecord::Migration
+class AddParticipansUniqueIndexMigration < ActiveRecord::Migration
   # Helper methods to ensure we're connecting to the right database, see
   # https://github.com/assaf/vanity/issues/295.
 
@@ -17,8 +17,11 @@ class AddVanityUniqueIndexes < ActiveRecord::Migration
 
   def change
     with_vanity_connection do
-      remove_index :vanity_participants, :name => "by_experiment_id_and_identity"
-      add_index :vanity_participants, [:experiment_id, :identity], :name => "by_experiment_id_and_alternative", :unique => true
+      remove_index :vanity_experiments, [:experiment_id]
+      add_index :vanity_experiments, [:experiment_id], :unique => true
+
+      remove_index :vanity_conversions, :name => "by_experiment_id_and_alternative", :unique => true
+      add_index :vanity_conversions, [:vanity_experiment_id, :alternative], :name => "by_experiment_id_and_alternative", :unique => true
     end
   end
 

--- a/lib/generators/templates/vanity_migration.rb
+++ b/lib/generators/templates/vanity_migration.rb
@@ -56,7 +56,7 @@ class VanityMigration < ActiveRecord::Migration
         t.timestamps null: false
       end
       add_index :vanity_participants, [:experiment_id]
-      add_index :vanity_participants, [:experiment_id, :identity], :name => "by_experiment_id_and_identity"
+      add_index :vanity_participants, [:experiment_id, :identity], :name => "by_experiment_id_and_identity", :unique => true
       add_index :vanity_participants, [:experiment_id, :shown], :name => "by_experiment_id_and_shown"
       add_index :vanity_participants, [:experiment_id, :seen], :name => "by_experiment_id_and_seen"
       add_index :vanity_participants, [:experiment_id, :converted], :name => "by_experiment_id_and_converted"

--- a/lib/generators/vanity/add_participants_unique_index_generator.rb
+++ b/lib/generators/vanity/add_participants_unique_index_generator.rb
@@ -1,0 +1,15 @@
+require 'rails/generators'
+require 'rails/generators/migration'
+
+class Vanity::AddParticipantsUniqueIndexGenerator < Rails::Generators::Base
+  include Rails::Generators::Migration
+  source_root File.expand_path('../../templates', __FILE__)
+
+  def self.next_migration_number(path)
+    Time.now.utc.strftime("%Y%m%d%H%M%S")
+  end
+
+  def create_model_file
+    migration_template "add_participants_unique_index_migration.rb", "db/migrate/add_participants_unique_index_migration.rb"
+  end
+end


### PR DESCRIPTION
Fixes a race condition that leads to multiple participant records for the same experiment/identity.  This could even lead to users w/ participation records in two different segments!!!

Thread A: `ab_test(:my_experiment)` => seen=0
Thread B: `ab_test(:my_experiment)` => seen=1

Solution:
* Add a unique index on `vanity_participants(experiment_id, identity)` (convert the existing index).
* Gracefully handle DUP_VAL_ON_INDEX errors when creating participant records.
