### PR TITLE
Fix broken table size in report dashboard

### DIFF
--- a/lib/vanity/templates/vanity.css
+++ b/lib/vanity/templates/vanity.css
@@ -13,15 +13,15 @@
 .vanity .experiment .status_disabled { background: #FEE }
 .vanity .experiment .enabled-links { float: right; font-weight: normal }
 
-.vanity .ab_test table { border-collapse: collapse; table-layout: fixed; width: 100%; border-bottom: 1px solid #ccc; margin: 1em 0 0 0 }
-.vanity .ab_test td { padding: .5em; border-top: 1px solid #ccc; width: 2em; overflow: hidden }
+.vanity .ab_test table { border-collapse: collapse; width: 100%; border-bottom: 1px solid #ccc; margin: 1em 0 0 0 }
+.vanity .ab_test td { padding: .5em; border-top: 1px solid #ccc; overflow: hidden }
 .vanity .ab_test .choice td { font-weight: bold; background: #f0f0f8 }
 .vanity .ab_test caption { caption-side: bottom; padding: .5em; background: transparent; text-align: left }
 .vanity .ab_test caption .disabled_info { padding-top: .5em }
-.vanity .ab_test td.option { width: 5em; white-space: nowrap; overflow: hidden }
+.vanity .ab_test td.option { white-space: nowrap; overflow: hidden }
 .vanity .ab_test td.option .default { font-size: 75% }
-.vanity .ab_test td.value { width: 8em; white-space: nowrap; overflow: hidden }
-.vanity .ab_test td.action { width: 6em; overflow: hidden; text-align: right }
+.vanity .ab_test td.value { white-space: nowrap; overflow: hidden }
+.vanity .ab_test td.action { overflow: hidden; text-align: right }
 .vanity .ab_test button.reset { float: right }
 
 .vanity .metrics { list-style: none; margin: 0; padding: 0; border-bottom: 1px solid #ddd }


### PR DESCRIPTION
Before:
<img width="921" alt="screen shot 2018-03-12 at 20 37 19" src="https://user-images.githubusercontent.com/1359698/37300638-80835168-2637-11e8-9364-648c2e698e40.png">

After:
<img width="784" alt="screen shot 2018-03-12 at 20 39 11" src="https://user-images.githubusercontent.com/1359698/37300655-8c9a2ae4-2637-11e8-95ed-cecbe6b8ba79.png">
