### PR TITLE
Upgrade yajl-ruby so that it can be compiled with ruby 2.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,11 +33,13 @@ GEM
     coffee-script-source (1.9.1)
     colorator (0.1)
     concurrent-ruby (1.0.5)
+    concurrent-ruby (1.0.5-java)
     crack (0.3.1)
     execjs (2.5.2)
     fakefs (0.6.7)
     fast-stemmer (1.0.2)
     ffi (1.9.8)
+    ffi (1.9.8-java)
     garb (0.9.1)
       activesupport (>= 2.2.0)
       crack (>= 0.1.6)
@@ -87,6 +89,11 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry (0.10.3-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
     pygments.rb (0.6.3)
       posix-spawn (~> 0.3.6)
       yajl-ruby (~> 1.2.0)
@@ -103,6 +110,8 @@ GEM
     safe_yaml (1.0.4)
     sass (3.4.13)
     slop (3.6.0)
+    spoon (0.0.6)
+      ffi
     sqlite3 (1.3.10)
     thor (0.19.1)
     timecop (0.3.5)
@@ -113,7 +122,7 @@ GEM
     webmock (1.8.0)
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
-    yajl-ruby (1.2.1)
+    yajl-ruby (1.2.3)
     yard (0.7.5)
 
 PLATFORMS
@@ -145,4 +154,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.13.0
+   1.16.4

--- a/vanity.gemspec
+++ b/vanity.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler",  ">= 1.8.0"
   spec.add_development_dependency "minitest", ">= 4.2"
-  spec.add_development_dependency "appraisal", "~> 1.0.2"
+  spec.add_development_dependency "appraisal", "~> 2.0.0"
   spec.add_development_dependency "timecop"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "fakefs"


### PR DESCRIPTION
Fix the bundle install error as yajl-ruby 1.2.1 not compatible with ruby 2.4
```
current directory: /Users/jiazhen/Documents/vanity/.bundle/gems/yajl-ruby-1.2.1/ext/yajl
make "DESTDIR="
compiling yajl.c
compiling yajl_alloc.c
compiling yajl_buf.c
compiling yajl_encode.c
compiling yajl_ext.c
yajl_ext.c:881:22: error: use of undeclared identifier 'rb_cFixnum'
    rb_define_method(rb_cFixnum, "to_json", rb_yajl_json_ext_fixnum_to_json, -1);
```