### PR TITLE
Fully destroy experiments using the Redis adapter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       addressable (>= 2.2.7)
       crack (>= 0.1.7)
     yajl-ruby (1.2.3)
-    yard (0.7.5)
+    yard (0.9.16)
 
 PLATFORMS
   java
@@ -154,4 +154,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.16.4
+   1.17.1

--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -217,9 +217,13 @@ module Vanity
       end
 
       def destroy_experiment(experiment)
-        @experiments.del "#{experiment}:outcome", "#{experiment}:created_at", "#{experiment}:completed_at"
-        alternatives = @experiments.keys("#{experiment}:alts:*")
-        @experiments.del(*alternatives) unless alternatives.empty?
+        cursor = nil
+
+        while cursor != "0" do
+          cursor, keys = @experiments.scan(cursor || "0", match: "#{experiment}:*")
+
+          @experiments.del(*keys) unless keys.empty?
+        end
       end
 
       protected

--- a/test/adapters/shared_tests.rb
+++ b/test/adapters/shared_tests.rb
@@ -123,6 +123,10 @@ module Vanity::Adapters::SharedTests
             @subject.destroy_experiment(experiment)
 
             refute(@subject.experiment_persisted?(experiment))
+            assert_equal(
+              { :participants => 0, :converted => 0, :conversions => 0 },
+              @subject.ab_counts(experiment, alternative)
+            )
           end
         end
 


### PR DESCRIPTION
Currently the redis adapter's `#destroy_experiment` method only removes experiment metadata; all participant data is retained even if the experiment is reset. This can lead to large numbers of old keys hanging around in redis instances, requiring manual cleanup.

This change uses redis's SCAN command[1] to delete all keys matching the experiment prefix, which should completely reset the experiment.

The SCAN command works in batches, each time returning a cursor value that can be used in subsequent calls; when the cursor "0" is returned, the scan is complete.

I've tried to test this here by making the shared adapter test more complete; I haven't got this running locally at the moment, however, so it's likely to be failing on travis and I'll patch it up with subsequent commits.

Is this something you'd be interested in merging, once the tests pass? The SCAN command was implemented in Redis 2.8.0, released in 2013; is this okay?

[1] https://redis.io/commands/scan