### PR TITLE
Fix Russian locale file key

### DIFF
--- a/lib/vanity/locales/vanity.ru.yml
+++ b/lib/vanity/locales/vanity.ru.yml
@@ -1,4 +1,4 @@
-en:
+ru:
   vanity:
     act_on_this_experiment:
       enable: 'Включить этот эксперимент'


### PR DESCRIPTION
When loading the Vanity dashboard with an English locale, all the
interface text was being shown in Russian.

We _think_ this is because the Russian locale file uses the `en:` key,
and as it loads after the English locale it is overwriting the English
values.

We've updated the Russian locale to use the `ru:` key.