### PR TITLE
Fix AbTest#alternative_for to always prefer persisted participants

### DIFF
--- a/lib/vanity/experiment/ab_test.rb
+++ b/lib/vanity/experiment/ab_test.rb
@@ -601,9 +601,10 @@ module Vanity
       # identity, and randomly distributed alternatives for each identity (in the
       # same experiment).
       def alternative_for(identity)
+        existing_assignment = connection.ab_assigned @id, identity
+        return existing_assignment if existing_assignment
+
         if @use_probabilities
-          existing_assignment = connection.ab_assigned @id, identity
-          return existing_assignment if existing_assignment
           random_outcome = rand()
           @use_probabilities.each do |alternative, max_prob|
             return alternative.id if random_outcome < max_prob


### PR DESCRIPTION
Prior to this fix, stubbing a specific outcome with AbTest#chooses
would occasionally set the 'shown' bit on a participant
because the code at
https://github.com/assaf/vanity/blob/469917acf/lib/vanity/experiment/ab_test.rb#L242
noticed that the persisted participant's alternative differed
from the alternative selected by the hashing algorithm in #alternative_for

This would cause problems downstream in the conversion code
because #ab_showing returns true on this participant.