### PR TITLE
Enable aliases for config

### DIFF
--- a/lib/vanity/configuration.rb
+++ b/lib/vanity/configuration.rb
@@ -213,7 +213,7 @@ module Vanity
       file_path = File.join(config_path, file_name)
 
       if File.exist?(file_path) # rubocop:todo Style/GuardClause
-        config = YAML.safe_load(ERB.new(File.read(file_path)).result)
+        config = YAML.safe_load(ERB.new(File.read(file_path)).result, [], [], true)
         config ||= {}
         params_for_environment = config[environment.to_s]
 

--- a/test/dummy/config/initializers/vanity.rb
+++ b/test/dummy/config/initializers/vanity.rb
@@ -1,0 +1,3 @@
+Vanity.configure do |config|
+  config.config_path = Rails.root.join('config')
+end

--- a/test/dummy/config/vanity.yml
+++ b/test/dummy/config/vanity.yml
@@ -1,0 +1,7 @@
+default: &default
+  some_key: true
+
+test:
+  <<: *default
+  adapter: mock
+  collecting: false


### PR DESCRIPTION
@bensheldon 
Rubocop changed `YAML.load` -> `YAML.safe_load` and safe_load doesn't support aliases in yml by default. This PR fixes that