### PR TITLE
Use Redis#exists? and fallback to #exists which could be either boolean or integer in recent redis gem versions

### DIFF
--- a/lib/vanity/adapters/redis_adapter.rb
+++ b/lib/vanity/adapters/redis_adapter.rb
@@ -117,7 +117,13 @@ module Vanity
 
       def is_experiment_completed?(experiment) # rubocop:todo Naming/PredicateName
         call_redis_with_failover do
-          @experiments.exists("#{experiment}:completed_at")
+          if @experiments.respond_to?(:exists?)
+            @experiments.exists?("#{experiment}:completed_at")
+          else
+            exists = @experiments.exists("#{experiment}:completed_at")
+
+            exists.is_a?(Numeric) ? exists > 0 : exists
+          end
         end
       end
 

--- a/test/adapters/redis_adapter_test.rb
+++ b/test/adapters/redis_adapter_test.rb
@@ -62,7 +62,7 @@ describe Vanity::Adapters::RedisAdapter do
 
   it "gracefully fails in #is_experiment_completed?" do
     redis_adapter, mocked_redis = stub_redis
-    mocked_redis.stubs(:exists).raises(RuntimeError)
+    mocked_redis.stubs(:exists?).raises(RuntimeError)
 
     assert_silent do
       redis_adapter.is_experiment_completed?("price_options")


### PR DESCRIPTION
Hello!

First of all thanks for this amazing library!

I'm trying to upgrade redis from 4.4 to 4.6 in my project. It's rather painless but I noticed Vanity wasn't working properly as it assumes `exists` to return true or false which in recent redis-rb versions was changed and now it returns number of matching keys unless `Redis.exists_returns_integer` is set to false. But that option is deprecated and will be removed in redis-rb 5.0. 

So for boolean checks it is recommended to use `exists?` method and right now it's a bit messy with all that possibilities out there. So I tried not to break anything by checking for `exists?` method which we now for sure gives us boolean result. And if that method is absent, we're probing `exists` and if it's numeric we are calculating `> 0` if not we're assuming it's boolean.

So what do you think about that?