### PR TITLE
Support Psych 4 safe_load

### DIFF
--- a/lib/vanity.rb
+++ b/lib/vanity.rb
@@ -17,6 +17,7 @@ module Vanity
 end
 
 require "vanity/version"
+require "vanity/safe_yaml"
 # Metrics
 require "vanity/metric/base"
 require "vanity/metric/active_record"

--- a/lib/vanity/configuration.rb
+++ b/lib/vanity/configuration.rb
@@ -213,7 +213,7 @@ module Vanity
       file_path = File.join(config_path, file_name)
 
       if File.exist?(file_path) # rubocop:todo Style/GuardClause
-        config = YAML.safe_load(ERB.new(File.read(file_path)).result, [], [], true)
+        config = SafeYAML.load(ERB.new(File.read(file_path)).result)
         config ||= {}
         params_for_environment = config[environment.to_s]
 

--- a/lib/vanity/safe_yaml.rb
+++ b/lib/vanity/safe_yaml.rb
@@ -1,0 +1,17 @@
+require "yaml"
+
+ module Vanity
+   module SafeYAML
+     begin
+       YAML.safe_load("---", permitted_classes: [])
+     rescue ArgumentError
+       def self.load(payload)
+         YAML.safe_load(payload, [], [], true)
+       end
+     else
+       def self.load(payload)
+         YAML.safe_load(payload, permitted_classes: [], permitted_symbols: [], aliases: true)
+       end
+     end
+   end
+ end


### PR DESCRIPTION
Attempts to add support for the new `safe_load` API in psych >= 3.1.0.

See: https://makandracards.com/makandra/465149-ruby-the-yaml-safe_load-method-hides-some-pitfalls#section-new-safe_load-api